### PR TITLE
K8SPG-86 Add short alias for source image

### DIFF
--- a/build/pgo-apiserver/Dockerfile
+++ b/build/pgo-apiserver/Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir -p build/_output/bin \
 RUN ./bin/license_aggregator.sh; \
     cp -r ./licenses /licenses
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal AS ubi8
 
 LABEL name="Percona Postgres Operator API server" \
       vendor="Percona" \

--- a/build/pgo-deployer/Dockerfile
+++ b/build/pgo-deployer/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal AS ubi8
 
 LABEL name="Percona Postgres Operator Deployer" \
       vendor="Percona" \

--- a/build/pgo-event/Dockerfile
+++ b/build/pgo-event/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal AS ubi8
 
 LABEL name="Event dispatcher for Percona Postgres Operator" \
       vendor="Percona" \

--- a/build/pgo-rmdata/Dockerfile
+++ b/build/pgo-rmdata/Dockerfile
@@ -22,7 +22,7 @@ RUN mkdir -p build/_output/bin \
 RUN ./bin/license_aggregator.sh; \
 	cp -r ./licenses /licenses
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal AS ubi8
 
 LABEL name="Data removal wrapper for Percona Postgres Operator" \
       vendor="Percona" \

--- a/build/pgo-scheduler/Dockerfile
+++ b/build/pgo-scheduler/Dockerfile
@@ -22,7 +22,7 @@ RUN mkdir -p build/_output/bin \
 RUN ./bin/license_aggregator.sh; \
 	cp -r ./licenses /licenses
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal AS ubi8
 
 LABEL name="Percona Postgres Operator task scheduler" \
 	  vendor="Percona" \

--- a/build/postgres-operator/Dockerfile
+++ b/build/postgres-operator/Dockerfile
@@ -22,7 +22,7 @@ RUN mkdir -p build/_output/bin \
 RUN ./bin/license_aggregator.sh; \
 	cp -r ./licenses /licenses
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal AS ubi8
 
 LABEL name="Percona Postgres Operator" \
       vendor="Percona" \


### PR DESCRIPTION
As it turns out, RedHat can't certify ubi based image
without short 'ubi8' alias stated in Dockerfiles