### PR TITLE
Allow specifying resoure request/limits for job containers

### DIFF
--- a/installers/helm/README.md
+++ b/installers/helm/README.md
@@ -52,6 +52,7 @@ be found in the [documentation](https://access.crunchydata.com/documentation/pos
 | rbac.useClusterAdmin | false | If enabled the ServiceAccount will be given cluster-admin privileges. |
 | serviceAccount.create | true | If false a ServiceAccount will not be created. A ServiceAccount must be created manually. |
 | serviceAccount.name | "" | Use to override the default ServiceAccount name. If serviceAccount.create is false this ServiceAccount will be used. |
+| `jobs.resources` | The [resources] to allocate for the job containers | undefined |
 
 {{% notice tip %}}
 If installing into an OpenShift 3.11 or Kubernetes 1.11 cluster `rbac.useClusterAdmin` must be enabled.

--- a/installers/helm/templates/_deployer_job_spec.yaml
+++ b/installers/helm/templates/_deployer_job_spec.yaml
@@ -5,7 +5,7 @@ spec:
     metadata:
       name: pgo-deploy
       labels:
-{{ include "postgres-operator.labels" . | indent 8 }} 
+{{ include "postgres-operator.labels" . | indent 8 }}
     spec:
       serviceAccountName: {{ include "postgres-operator.serviceAccountName" . }}
       restartPolicy: Never
@@ -19,6 +19,10 @@ spec:
         volumeMounts:
           - name: deployer-conf
             mountPath: "/conf"
+{{- if .Values.jobs.resources }}
+        resources:
+{{ toYaml .Values.jobs.resources | indent 10 }}
+{{- end }}
       volumes:
         - name: deployer-conf
           configMap:

--- a/installers/helm/values.yaml
+++ b/installers/helm/values.yaml
@@ -22,10 +22,10 @@ jobs:
   resources: {}
     # requests:
     #   cpu: 250m
-    #   memory: 128Mi
+    #   memory: 256Mi
     # limits:
     #   cpu: 250m
-    #   memory: 128Mi
+    #   memory: 256Mi
 
 # =====================
 # Configuration Options
@@ -85,7 +85,7 @@ pgo_client_version: "4.7.3"
 pgo_cluster_admin: "false"
 pgo_disable_eventing: "false"
 pgo_disable_tls: "false"
-pgo_image_prefix: "registry.developers.crunchydata.com/crunchydata"
+pgo_image_prefix: "percona/percona-postgresql-operator"
 pgo_image_pull_secret: ""
 pgo_image_pull_secret_manifest: ""
 pgo_image_tag: "centos8-4.7.3"

--- a/installers/helm/values.yaml
+++ b/installers/helm/values.yaml
@@ -18,6 +18,15 @@ serviceAccount:
     # serviceAccount.name: The name of the Service Account to create or use
     name: ""
 
+jobs:
+  resources: {}
+    # requests:
+    #   cpu: 250m
+    #   memory: 128Mi
+    # limits:
+    #   cpu: 250m
+    #   memory: 128Mi
+
 # =====================
 # Configuration Options
 # More info for these options can be found in the docs


### PR DESCRIPTION
When deploying the operator using Helm inside of a specific namespace (not cluster scoped), for our particular use case resource requests/limits are mandatory. Pods will fail to start if they are not specified. This adds the options to set these for the `install/uninstall/upgrade` job containers.