### PR TITLE
K8SPG-195: Fix pgbouncer TLS error

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -636,7 +636,7 @@ enable_pgBouncer() {
 		--type json \
 		-p='[{"op":"replace","path":"/spec/pgBouncer/size","value":'${replicas_num}'}]'
 	sleep 15
-	kubectl_bin wait --for=condition=Available "deployment/${cluster}-pgbouncer"
+	kubectl_bin wait --timeout=300s --for=condition=Available "deployment/${cluster}-pgbouncer"
 }
 
 disable_pgBouncer() {
@@ -644,7 +644,7 @@ disable_pgBouncer() {
 		"perconapgcluster/${1}" \
 		--type json \
 		-p='[{"op":"replace","path":"/spec/pgBouncer/size","value":0}]'
-	kubectl_bin wait --for=delete "deployment/${1}-pgbouncer"
+	kubectl_bin wait --timeout=300s --for=delete "deployment/${1}-pgbouncer"
 }
 
 compare_kubectl() {

--- a/e2e-tests/upgrade/run
+++ b/e2e-tests/upgrade/run
@@ -161,7 +161,12 @@ main() {
 			{"op":"add","path":"/spec/sslCA","value":'"'${cluster}-ssl-ca'"'},
 			{"op":"add","path":"/spec/sslSecretName","value":'"'${cluster}-ssl-keypair'"'},
 			{"op":"add","path":"/spec/sslReplicationSecretName","value":'"'${cluster}-ssl-keypair'"'},
+			{"op":"add","path":"/spec/pgBouncer/tlsSecret","value":'"'${cluster}-ssl-keypair'"'},
 		]'
+
+	disable_pgBouncer ${cluster}
+	enable_pgBouncer ${cluster}
+
 	#	wait_cluster_consistency "${cluster}"
 	#	wait_deployment "${cluster}"
 	#	wait_deployment "${cluster}-pgbouncer"


### PR DESCRIPTION
TLS options included in pgbouncer template only if
spec.pgBouncer.tlsSecret, spec.sslCA and spec.sslSecretName is not
empty. But just updating these fields is not enough, you need to disable
pgbouncer and enable it back by setting replicas to 0 and 1.
Unfortunately deleting the deployment object doesn't work since the
operator doesn't re-create it.