### PR TITLE
K8SPG-204 Enable Openshift detection by default

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -161,7 +161,6 @@ data:
     delete_operator_namespace: "false"
     delete_watched_namespaces: "false"
     disable_auto_failover: "false"
-    disable_fsgroup: "false"
     reconcile_rbac: "true"
     exporterport: "9187"
     metrics: "false"


### PR DESCRIPTION
Explicitly stated option does not let operator to manage
pod FSgroup flawlessly