### PR TITLE
K8SPG-207: Add verifyTLS param to Pgtask/restore

### DIFF
--- a/deploy/backup/restore.yaml
+++ b/deploy/backup/restore.yaml
@@ -13,4 +13,5 @@ spec:
     backrest-restore-from-cluster: cluster1
     backrest-restore-opts: --type=time --target="2021-04-16 15:13:32"
     backrest-storage-type: posix
+    backrest-s3-verify-tls: "true"
   tasktype: restore

--- a/internal/operator/backrest/restore.go
+++ b/internal/operator/backrest/restore.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/percona/percona-postgresql-operator/internal/config"
 	"github.com/percona/percona-postgresql-operator/internal/kubeapi"
+	"github.com/percona/percona-postgresql-operator/internal/operator"
 	"github.com/percona/percona-postgresql-operator/internal/util"
 	crv1 "github.com/percona/percona-postgresql-operator/pkg/apis/crunchydata.com/v1"
 	"github.com/percona/percona-postgresql-operator/pkg/events"
@@ -67,6 +68,14 @@ func UpdatePGClusterSpecForRestore(clientset kubeapi.Interface, cluster *crv1.Pg
 	storageType := task.Spec.Parameters[config.LABEL_BACKREST_STORAGE_TYPE]
 	if storageType != "" && !strings.Contains(restoreOpts, "--repo-type") {
 		restoreOpts = fmt.Sprintf("%s --repo-type=%s", restoreOpts, storageType)
+	}
+
+	verifyTLS, ok := task.Spec.Parameters[config.LABEL_BACKREST_S3_VERIFY_TLS]
+	if !ok {
+		verifyTLS = operator.GetS3VerifyTLSSetting(cluster)
+	}
+	if verifyTLS == "false" {
+		restoreOpts = fmt.Sprintf("%s --no-repo1-s3-verify-tls", restoreOpts)
 	}
 
 	cluster.Spec.PGDataSource.RestoreOpts = restoreOpts


### PR DESCRIPTION
It's also a problem in upstream. `pgbackrest/create-replica.sh` script try to detect the repo type using a file in `/pgconf` but these file only exists in case the cluster in standby mode. So it fails to detect the repo type is s3 and doesn't add the required flag to skip TLS verification.

We'll handle `backrest-s3-verify-tls` parameter in restore like Pgtask/backup to control the behaviour on restore level. If there's no parameter the operator will try to detect it itself using the pgcluster spec.