### PR TITLE
K8SPG-238 Minor test update

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -124,7 +124,7 @@ create_namespace() {
 deploy_cert_manager() {
 	kubectl_bin create namespace cert-manager || :
 	kubectl_bin label namespace cert-manager certmanager.k8s.io/disable-validation=true || :
-	kubectl_bin apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.0.4/cert-manager.yaml --validate=false || : 2>/dev/null
+	kubectl_bin apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.9.0/cert-manager.yaml --validate=false || : 2>/dev/null
 	sleep 30
 }
 
@@ -250,11 +250,11 @@ deploy_minio() {
 		--set tls.certSecret=minio-gw-tls \
 		--set tls.publicCrt=tls.crt \
 		--set tls.privateKey=tls.key \
-		--set buckets[0].name=${BUCKET} \
-		--set buckets[0].policy=public \
 		minio/minio
 	MINIO_POD=$(kubectl_bin get pods --selector=release=minio-service -o 'jsonpath={.items[].metadata.name}')
 	wait_pod $MINIO_POD
+	kubectl_bin run -i aws-cli --rm --image=perconalab/awscli --restart=Never \
+		--overrides='{"spec":{"containers":[{"args":["/usr/bin/env","AWS_ACCESS_KEY_ID=some-access-key","AWS_SECRET_ACCESS_KEY=some-secret-key","AWS_DEFAULT_REGION=us-east-1","AWS_CA_BUNDLE=/tmp/CAs/ca.crt","/usr/bin/aws","--endpoint-url","https://minio-service:9000","s3","mb","s3://pg-operator-testing"],"imagePullPolicy":"Always","image":"perconalab/awscli","name":"awscli","volumeMounts":[{"mountPath":"/tmp/CAs","name":"minio-ca"}]}],"volumes":[{"name":"minio-ca","secret":{"defaultMode":420,"items":[{"key":"ca.crt","path":"ca.crt"}],"secretName":"minio-gw-tls"}}]}}'
 }
 
 destroy_minio() {


### PR DESCRIPTION
In order to get the smooth operation of TLS related part of
demand-backup test cert-manager has to be updated
Also, openshift does not let minio native bucket creation job finish, so
switching back to the explicit awscli call with CA injected