### PR TITLE
K8SPG-238 1.24 compatibility for test infra

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -742,6 +742,7 @@ compare_kubectl() {
 		| yq d - '**."kubernetes.io/pvc-protection"' \
 		| yq d - '**.volumeName' \
 		| yq d - '**."volume.beta.kubernetes.io/storage-provisioner"' \
+		| yq d - '**."volume.kubernetes.io/storage-provisioner"' \
 		| yq d - 'spec.volumeMode' \
 		| yq d - 'spec.nodeName' \
 		| yq d - '**."volume.kubernetes.io/selected-node"' \


### PR DESCRIPTION
Since storage-provisioner is no longer in Beta in 1.24 we need to
adjust our framework accordingly