### PR TITLE
K8SPG-239 Disable telemetry transfer by default in e2e-testing

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -152,7 +152,7 @@ prepare_operator_yaml() {
 	local namespace_mode=${3:-"disabled"}
 	local operator_action=${4:-"install"}
 	local namespace=${5:-"$namespace"}
-	local dont_send_telemetry=${6:-"false"}
+	local dont_send_telemetry=${6:-"true"}
 
 	yq r -d'2' "${operator_manifest}" 'data[values.yaml]' \
 		| $sed -e "s#^namespace: .*#namespace: \"${namespace}\"#g" \


### PR DESCRIPTION
In order to get rid of unneccessary fuzz in our analitycs on
check.percona.com side, we are to disable the setting by default