### PR TITLE
Change pgbackrest-repo container name

### DIFF
--- a/percona/templates/pgo-backrest-repo-template.json
+++ b/percona/templates/pgo-backrest-repo-template.json
@@ -58,7 +58,7 @@
                 "tolerations": {{ .Tolerations }},
                 {{ end }}
                 "containers": [{
-                    "name": "database",
+                    "name": "backrest-repo",
                     "image": "{{.Image}}",
                     "imagePullPolicy": "<imagePullPolicy>",
                     "securityContext": {


### PR DESCRIPTION
The container name in the pgbackrest-repo is `database` like the pgprimary or the pgreplicas pods, but it's not running a postgresql database.