### PR TITLE
Pass PerconaPGCluster.PGPrimary.Annotations to Pgcluster.Annotations.Postgres

### DIFF
--- a/percona/controllers/pgcluster/pgcluster.go
+++ b/percona/controllers/pgcluster/pgcluster.go
@@ -359,6 +359,7 @@ func getPGCluster(pgc *crv1.PerconaPGCluster, cluster *crv1.Pgcluster) *crv1.Pgc
 	cluster.Spec.SyncReplication = syncReplication
 	cluster.Spec.UserLabels = userLabels
 	cluster.Spec.Annotations.Global = specAnnotationsGlobal
+	cluster.Spec.Annotations.Postgres = pgc.Spec.PGPrimary.Annotations
 	cluster.Spec.Tolerations = pgc.Spec.PGPrimary.Tolerations
 	storageMap := map[crv1.BackrestStorageType]crv1.BackrestStorageType{
 		crv1.BackrestStorageTypeLocal: crv1.BackrestStorageTypeLocal,


### PR DESCRIPTION
Currently `PGPrimary.Annotations` are ignored.
Both `PGPrimary` and `Pgcluster` specs allow them, but the controller is not forwarding them. Only Global Annotations are passed from `PerconaPGCluster` to `Pgcluster`

This patch allows the Annotations in `PerconaPGCluster.PGPrimary` to be propagated to `Primary` and `Replica` Deployment Pods.