### PR TITLE
K8SPG-265 A minor fix for monitoring test

### DIFF
--- a/e2e-tests/tests/monitoring/01-assert.yaml
+++ b/e2e-tests/tests/monitoring/01-assert.yaml
@@ -7,7 +7,6 @@ kind: StatefulSet
 metadata:
   name: pmm
 status:
-  availableReplicas: 1
   collisionCount: 0
   currentReplicas: 1
   observedGeneration: 1

--- a/e2e-tests/tests/monitoring/03-check-metrics.yaml
+++ b/e2e-tests/tests/monitoring/03-check-metrics.yaml
@@ -10,6 +10,6 @@ commands:
       api_key=$(kubectl get -n "${NAMESPACE}" secret monitoring-pmm-secret -o jsonpath='{.data.PMM_SERVER_KEY}' | base64 --decode)
       instance=$(kubectl get -n "${NAMESPACE}" pod -l postgres-operator.crunchydata.com/instance-set=instance1 -o 'jsonpath={.items[].metadata.name}')
 
-      get_metric_values node_boot_time_seconds ${instance} ${api_key}
-      get_qan20_values ${instance} ${api_key}
+      get_metric_values node_boot_time_seconds ${NAMESPACE}-${instance} ${api_key}
+      get_qan20_values ${NAMESPACE}-${instance} ${api_key}
     timeout: 120


### PR DESCRIPTION
It turns out that pmm-server treats a node as entity with namespace as prefix inside a name