### PR TITLE
CLOUD-756 - Fix pipeline to delete/post GH results only if no new build initiated

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -375,7 +375,7 @@ pipeline {
         always {
             script {
                 setTestsresults()
-                if (currentBuild.result != null && currentBuild.result != 'SUCCESS' && currentBuild.result != 'NOT_BUILT') {
+                if (currentBuild.result != null && currentBuild.result != 'SUCCESS' && currentBuild.nextBuild == null) {
                     try {
                         slackSend channel: "@${AUTHOR_NAME}", color: '#FF0000', message: "[${JOB_NAME}]: build ${currentBuild.result}, ${BUILD_URL} owner: @${AUTHOR_NAME}"
                     }
@@ -383,7 +383,7 @@ pipeline {
                         slackSend channel: '#cloud-dev-ci', color: '#FF0000', message: "[${JOB_NAME}]: build ${currentBuild.result}, ${BUILD_URL} owner: @${AUTHOR_NAME}"
                     }
                 }
-                if (env.CHANGE_URL) {
+                if (env.CHANGE_URL && currentBuild.nextBuild == null) {
                     for (comment in pullRequest.comments) {
                         println("Author: ${comment.user}, Comment: ${comment.body}")
                         if (comment.user.equals('JNKPercona')) {
@@ -391,13 +391,11 @@ pipeline {
                             comment.delete()
                         }
                     }
-                    if (currentBuild.result != 'NOT_BUILT') {
-                        makeReport()
-                        unstash 'IMAGE'
-                        def IMAGE = sh(returnStdout: true, script: "cat results/docker/TAG").trim()
-                        TestsReport = TestsReport + "\r\n\r\ncommit: ${env.CHANGE_URL}/commits/${env.GIT_COMMIT}\r\nimage: `${IMAGE}`\r\n"
-                        pullRequest.comment(TestsReport)
-                    }
+                    makeReport()
+                    unstash 'IMAGE'
+                    def IMAGE = sh(returnStdout: true, script: "cat results/docker/TAG").trim()
+                    TestsReport = TestsReport + "\r\n\r\ncommit: ${env.CHANGE_URL}/commits/${env.GIT_COMMIT}\r\nimage: `${IMAGE}`\r\n"
+                    pullRequest.comment(TestsReport)
                 }
             }
             DeleteOldClusters("$CLUSTER_NAME")


### PR DESCRIPTION

**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [ ] Have you updated or added documentation for the change, as applicable?
 - [x] Have you tested your changes on all related environments with successful results, as applicable?
   - [ ] Have you added automated tests?



**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] New feature
 - [x] Bug fix
 - [ ] Documentation
 - [x] Testing enhancement
 - [ ] Other


**What is the current behavior (link to any open issues here)?**
Old build can delete github results from the build which was initiated later in the pipeline.


**What is the new behavior (if this is a feature change)?**
If current build is not the latest do not delete the github results and do not post new results - we just don't care about this build results since we already know there is a newer one.


**Other Information**:
