### PR TITLE
CLOUD-765 Gracefully remove cluster object for namespace deletion

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -204,6 +204,7 @@ void prepareNode() {
         rm -f "${KREW}.tar.gz"
         export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
         kubectl krew install kuttl
+        printf "%s is installed" "$(kubectl kuttl --version)"
     '''
 }
 

--- a/e2e-tests/kuttl.yaml
+++ b/e2e-tests/kuttl.yaml
@@ -2,3 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 testDirs:
 - e2e-tests/tests
+timeout: 180

--- a/e2e-tests/tests/demand-backup/08-remove-cluster-gracefully.yaml
+++ b/e2e-tests/tests/demand-backup/08-remove-cluster-gracefully.yaml
@@ -1,0 +1,12 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: pg.percona.com/v2beta1
+  kind: PerconaPGCluster
+  metadata:
+    name: demand-backup
+- apiVersion: postgres-operator.crunchydata.com/v1beta1
+  kind: PostgresCluster
+  metadata:
+    name: demand-backup
+

--- a/e2e-tests/tests/init-deploy/04-remove-cluster-gracefully.yaml
+++ b/e2e-tests/tests/init-deploy/04-remove-cluster-gracefully.yaml
@@ -1,0 +1,12 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: pg.percona.com/v2beta1
+  kind: PerconaPGCluster
+  metadata:
+    name: init-deploy
+- apiVersion: postgres-operator.crunchydata.com/v1beta1
+  kind: PostgresCluster
+  metadata:
+    name: init-deploy
+

--- a/e2e-tests/tests/monitoring/04-remove-cluster-gracefully.yaml
+++ b/e2e-tests/tests/monitoring/04-remove-cluster-gracefully.yaml
@@ -1,0 +1,12 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: pg.percona.com/v2beta1
+  kind: PerconaPGCluster
+  metadata:
+    name: monitoring
+- apiVersion: postgres-operator.crunchydata.com/v1beta1
+  kind: PostgresCluster
+  metadata:
+    name: monitoring
+

--- a/e2e-tests/tests/start-from-backup/03-remove-cluster-gracefully.yaml
+++ b/e2e-tests/tests/start-from-backup/03-remove-cluster-gracefully.yaml
@@ -1,0 +1,12 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: pg.percona.com/v2beta1
+  kind: PerconaPGCluster
+  metadata:
+    name: start-from-backup
+- apiVersion: postgres-operator.crunchydata.com/v1beta1
+  kind: PostgresCluster
+  metadata:
+    name: start-from-backup
+


### PR DESCRIPTION
Since the operator does not support the legit way for removing finalizer from the calculated cluster object, let's remove the object gracefully as it's supposed to be deleted by user.

