### PR TITLE
K8SPG-269: Pass pgPrimary affinity config to backup pods

### DIFF
--- a/internal/operator/backrest/backup.go
+++ b/internal/operator/backrest/backup.go
@@ -65,6 +65,10 @@ type backrestJobTemplateFields struct {
 	PgbackrestRestoreVolumes      string
 	PgbackrestRestoreVolumeMounts string
 	Tolerations                   string
+	NodeSelector                  string
+	PodAntiAffinity               string
+	PodAntiAffinityLabelName      string
+	PodAntiAffinityLabelValue     string
 }
 
 var (
@@ -139,6 +143,10 @@ func Backrest(namespace string, clientset kubeapi.Interface, task *crv1.Pgtask) 
 		BackrestLocalAndS3Storage:     operator.IsLocalAndS3Storage(cluster),
 		PgbackrestS3VerifyTLS:         task.Spec.Parameters[config.LABEL_BACKREST_S3_VERIFY_TLS],
 		Tolerations:                   util.GetTolerations(cluster.Spec.Tolerations),
+		NodeSelector:                  operator.GetNodeAffinity(cluster.Spec.NodeAffinity.Default),
+		PodAntiAffinity:               operator.GetPodAntiAffinity(cluster, crv1.PodAntiAffinityDeploymentDefault, cluster.Spec.PodAntiAffinity.Default),
+		PodAntiAffinityLabelName:      config.LABEL_POD_ANTI_AFFINITY,
+		PodAntiAffinityLabelValue:     string(cluster.Spec.PodAntiAffinity.Default),
 	}
 
 	podCommandOpts, err := getCommandOptsFromPod(clientset, task, namespace)

--- a/percona/controllers/template/template.go
+++ b/percona/controllers/template/template.go
@@ -26,6 +26,11 @@ const (
 func UpdateBackrestJobTemplate(backrestJobTemplateData []byte, newCluster *crv1.PerconaPGCluster) error {
 	templateData := handleImagePullPolicy(backrestJobTemplateData, []byte(newCluster.Spec.Backup.ImagePullPolicy))
 
+	templateData, err := handleAffinityTemplate(templateData, newCluster.Spec.PGPrimary.Affinity, true)
+	if err != nil {
+		return errors.Wrap(err, "handle affinity template data")
+	}
+
 	t, err := template.New(BackrestJobTemplateName).Parse(string(templateData))
 	if err != nil {
 		return errors.Wrap(err, "parse template")

--- a/percona/templates/backrest-job.json
+++ b/percona/templates/backrest-job.json
@@ -109,6 +109,7 @@
                         }
                     }]
                 }],
+                "affinity": <affinity>,
                 "restartPolicy": "Never"
             }
         }


### PR DESCRIPTION
We re-use pgPrimary affinity options in backup pods too.