### PR TITLE
K8SPG-286: Use TLS for PMM client connections

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -6,9 +6,9 @@ metadata:
   name: cluster1
 spec:
 #  secretsName: cluster1-users
-#  sslCA: cluster1-ssl-ca
-#  sslSecretName: cluster1-ssl-keypair
-#  sslReplicationSecretName: cluster1-ssl-keypair
+  sslCA: cluster1-ssl-ca
+  sslSecretName: cluster1-ssl-keypair
+  sslReplicationSecretName: cluster1-ssl-keypair
   upgradeOptions:
     versionServiceEndpoint: https://check.percona.com
     apply: disabled

--- a/percona/controllers/pgc/pgc.go
+++ b/percona/controllers/pgc/pgc.go
@@ -554,7 +554,7 @@ func (c *Controller) onUpdate(oldObj, newObj interface{}) {
 			return
 		}
 	}
-	if oldCluster.Spec.TlSOnly != newCluster.Spec.TlSOnly {
+	if oldCluster.Spec.TLSOnly != newCluster.Spec.TLSOnly {
 		err = pgcluster.RestartPgBouncer(c.Client, newCluster)
 		if err != nil {
 			log.Errorf("update perconapgcluster: restart pgbouncer: %s", err)

--- a/percona/controllers/pgc/tls.go
+++ b/percona/controllers/pgc/tls.go
@@ -20,9 +20,10 @@ import (
 )
 
 func (c *Controller) handleTLS(cr *crv1.PerconaPGCluster) error {
-	if !cr.Spec.TlSOnly {
+	if !cr.TLSEnabled() {
 		return nil
 	}
+
 	err := c.createSSLByCertManager(cr)
 	if err != nil {
 		if cr.Spec.TLS != nil && cr.Spec.TLS.IssuerConf != nil {

--- a/percona/controllers/pgcluster/pgcluster.go
+++ b/percona/controllers/pgcluster/pgcluster.go
@@ -390,7 +390,7 @@ func getPGCluster(pgc *crv1.PerconaPGCluster, cluster *crv1.Pgcluster) *crv1.Pgc
 	cluster.Spec.PGDataSource.RestoreFrom = pgc.Spec.PGDataSource.RestoreFrom
 	cluster.Spec.PGDataSource.RestoreOpts = pgc.Spec.PGDataSource.RestoreOpts
 	cluster.Spec.ServiceType = pgc.Spec.PGPrimary.Expose.ServiceType
-	cluster.Spec.TLSOnly = pgc.Spec.TlSOnly
+	cluster.Spec.TLSOnly = pgc.Spec.TLSOnly
 	cluster.Spec.Standby = pgc.Spec.Standby
 	cluster.Spec.Shutdown = pgc.Spec.Pause
 	cluster.Spec.CustomConfig = pgc.Spec.PGPrimary.Customconfig

--- a/pkg/apis/crunchydata.com/v1/percona-cluster.go
+++ b/pkg/apis/crunchydata.com/v1/percona-cluster.go
@@ -34,7 +34,7 @@ type PerconaPGClusterSpec struct {
 	TablespaceStorages       map[string]PVCStorage  `json:"tablespaceStorages"`
 	Pause                    bool                   `json:"pause"`
 	Standby                  bool                   `json:"standby"`
-	TlSOnly                  bool                   `json:"tlsOnly"`
+	TLSOnly                  bool                   `json:"tlsOnly"`
 	DisableAutofail          bool                   `json:"disableAutofail"`
 	KeepData                 bool                   `json:"keepData"`
 	KeepBackups              bool                   `json:"keepBackups"`
@@ -294,4 +294,8 @@ func (p *PerconaPGCluster) checkAndSetAffinity(clusterName string) {
 	if p.Spec.Backup.Affinity.Advanced == nil && len(p.Spec.Backup.Affinity.AntiAffinityType) == 0 {
 		p.Spec.Backup.Affinity.AntiAffinityType = "preferred"
 	}
+}
+
+func (p *PerconaPGCluster) TLSEnabled() bool {
+	return (p.Spec.SSLSecretName != "" && p.Spec.SSLCA != "")
 }


### PR DESCRIPTION
This commit also fixes how our controller detects if TLS enabled or not. Before these changes, we were checking `spec.TLSOnly` for it but Crunchy's controller checks `spec.sslCA` and `spec.sslSecretName` fields. So if only `TLSOnly` is enabled, Crunchy controller doesn't mount TLS secrets to deployments. Now both controller are aligned.
