### PR TITLE
K8SPG-316: Run operator in namespace scope with OLM

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -9,18 +9,9 @@ images:
   newName: perconalab/percona-postgresql-operator
   newTag: main
 
-patchesJson6902:
-- patch: |-
-    - op: remove
-      path: /spec/template/spec/containers/0/env/1
-  target:
-    group: apps
-    kind: Deployment
-    name: percona-postgresql-operator
-    version: v1
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../crd
-- ../rbac/cluster
+- ../rbac/namespace
 - ../manager

--- a/installers/olm/generate.sh
+++ b/installers/olm/generate.sh
@@ -28,7 +28,7 @@ operator_yamls=$(kubectl kustomize "config/${DISTRIBUTION}")
 operator_crds=$(yq <<< "${operator_yamls}" --slurp --yaml-roundtrip 'map(select(.kind == "CustomResourceDefinition"))')
 operator_deployments=$(yq <<< "${operator_yamls}" --slurp --yaml-roundtrip 'map(select(.kind == "Deployment"))')
 operator_accounts=$(yq <<< "${operator_yamls}" --slurp --yaml-roundtrip 'map(select(.kind == "ServiceAccount"))')
-operator_roles=$(yq <<< "${operator_yamls}" --slurp --yaml-roundtrip 'map(select(.kind == "ClusterRole"))')
+operator_roles=$(yq <<< "${operator_yamls}" --slurp --yaml-roundtrip 'map(select(.kind == "Role"))')
 
 # Recreate the Operator SDK project.
 [ ! -d "${project_directory}" ] || rm -r "${project_directory}"


### PR DESCRIPTION
[![K8SPG-316](https://badgen.net/badge/JIRA/K8SPG-316/green)](https://jira.percona.com/browse/K8SPG-316) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
OLM installations don't work because of missing permissions in cluster scope.

**Cause:**
Operator runs in cluster wide mode if `PGO_TARGET_NAMESPACE` env variable is empty. 

**Solution:**
Ensure `PGO_TARGET_NAMESPACE` exists in operator deployment in CSV and use proper role.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PG version?
- [x] Does the change support oldest and newest supported Kubernetes version?