### PR TITLE
K8SPG-334: PMM fixes and improvements

### DIFF
--- a/percona/controller/pgcluster/status.go
+++ b/percona/controller/pgcluster/status.go
@@ -62,6 +62,10 @@ func (r *PGClusterReconciler) getState(cr *v2beta1.PerconaPGCluster, status *v1b
 		return v2beta1.AppStateInit
 	}
 
+	if size == 0 {
+		return v2beta1.AppStateInit
+	}
+
 	return v2beta1.AppStateReady
 }
 

--- a/percona/k8s/util.go
+++ b/percona/k8s/util.go
@@ -1,8 +1,15 @@
 package k8s
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"os"
 	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // GetOperatorNamespace returns the namespace of the operator pod
@@ -13,4 +20,29 @@ func GetOperatorNamespace() (string, error) {
 	}
 
 	return strings.TrimSpace(string(nsBytes)), nil
+}
+
+func ObjectHash(obj runtime.Object) (string, error) {
+	var dataToMarshal interface{}
+
+	switch object := obj.(type) {
+	case *appsv1.StatefulSet:
+		dataToMarshal = object.Spec
+	case *appsv1.Deployment:
+		dataToMarshal = object.Spec
+	case *corev1.Service:
+		dataToMarshal = object.Spec
+	case *corev1.Secret:
+		dataToMarshal = object.Data
+	default:
+		dataToMarshal = obj
+	}
+
+	data, err := json.Marshal(dataToMarshal)
+	if err != nil {
+		return "", err
+	}
+
+	hash := sha256.Sum256(data)
+	return hex.EncodeToString(hash[:]), nil
 }

--- a/pkg/apis/pg.percona.com/v2beta1/perconapgcluster_types.go
+++ b/pkg/apis/pg.percona.com/v2beta1/perconapgcluster_types.go
@@ -523,6 +523,12 @@ type PerconaPGClusterList struct {
 	Items           []PerconaPGCluster `json:"items"`
 }
 
+const labelPrefix = "pg.percona.com/"
+
+const (
+	LabelPMMSecret = labelPrefix + "pmm-secret"
+)
+
 const annotationPrefix = "pg.percona.com/"
 
 const (
@@ -538,6 +544,10 @@ const (
 	// timestamp), which will be stored in the PostgresCluster status to properly track completion
 	// of the Job.
 	AnnotationPGBackRestRestore = annotationPrefix + "pgbackrest-restore"
+
+	// PMMSecretHash is the annotation that is added to instance annotations to
+	// rollout restart PG pods in case PMM credentials are rotated.
+	AnnotationPMMSecretHash = annotationPrefix + "pmm-secret-hash"
 )
 
 const DefaultVersionServiceEndpoint = "https://check.percona.com"


### PR DESCRIPTION
[![K8SPG-334](https://badgen.net/badge/JIRA/K8SPG-334/green)](https://jira.percona.com/browse/K8SPG-334) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
1. postgres-exporter doesn't work with passwords with commas.
2. reconciliation errors if user defines `monitor` user in CR.
3. we need to restart PG pods if PMM API key is rotated.
4. CR status is ready right after cluster is created and then becomes initializing.

**Solution:**
1. Use only alphanumeric characters for monitor user.
2. Ignore `monitor` user in CR.
3. We watch for changes in PMM secret and update pod annotations with secret hash to restart pods.
4. If size is 0 and cluster is not paused, state should be initializing.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PG version?
- [x] Does the change support oldest and newest supported Kubernetes version?

**PLEASE DON'T SQUASH AND MERGE, COMMITS ARE SEPARATE**.