### PR TITLE
K8SPG-360: trigger reconcile on secrets update

### DIFF
--- a/internal/controller/postgrescluster/controller.go
+++ b/internal/controller/postgrescluster/controller.go
@@ -466,6 +466,7 @@ func (r *Reconciler) SetupWithManager(mgr manager.Manager) error {
 		Owns(&batchv1.CronJob{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
 		Watches(&source.Kind{Type: &corev1.Pod{}}, r.watchPods()).
+		Watches(&source.Kind{Type: &corev1.Secret{}}, r.watchSecrets()).
 		Watches(&source.Kind{Type: &appsv1.StatefulSet{}},
 			r.controllerRefHandlerFuncs()). // watch all StatefulSets
 		Complete(r)

--- a/internal/controller/postgrescluster/watches.go
+++ b/internal/controller/postgrescluster/watches.go
@@ -16,6 +16,9 @@
 package postgrescluster
 
 import (
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -51,6 +54,24 @@ func (*Reconciler) watchPods() handler.Funcs {
 			if len(cluster) != 0 &&
 				(patroni.PodRequiresRestart(e.ObjectOld) ||
 					patroni.PodRequiresRestart(e.ObjectNew)) {
+				q.Add(reconcile.Request{NamespacedName: client.ObjectKey{
+					Namespace: e.ObjectNew.GetNamespace(),
+					Name:      cluster,
+				}})
+				return
+			}
+		},
+	}
+}
+
+func (*Reconciler) watchSecrets() handler.Funcs {
+	return handler.Funcs{
+		UpdateFunc: func(e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+			labels := e.ObjectNew.GetLabels()
+			cluster := labels[naming.LabelCluster]
+
+			if len(cluster) != 0 &&
+				!reflect.DeepEqual(e.ObjectNew.(*corev1.Secret).Data, e.ObjectOld.(*corev1.Secret).Data) {
 				q.Add(reconcile.Request{NamespacedName: client.ObjectKey{
 					Namespace: e.ObjectNew.GetNamespace(),
 					Name:      cluster,


### PR DESCRIPTION
https://jira.percona.com/browse/K8SPG-360

**DESCRIPTION**
---
**Problem:**
*When cluster is ready, patching secrets doesn't affect cluster at all. Even if secret is patched with empty password, it's not regenerated*

**Cause:**
*Reconcile is not triggered on secrets update.*

**Solution:**
*Trigger reconcile when `.data` of the secret is changed.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
