### PR TITLE
K8SPG-302 - Update tests for minikube and add run-minikube.csv

### DIFF
--- a/e2e-tests/run-minikube.csv
+++ b/e2e-tests/run-minikube.csv
@@ -1,0 +1,5 @@
+demand-backup
+init-deploy
+scheduled-backup
+start-from-backup
+telemetry-transfer

--- a/e2e-tests/run-release.csv
+++ b/e2e-tests/run-release.csv
@@ -1,0 +1,6 @@
+demand-backup
+init-deploy
+monitoring
+scheduled-backup
+start-from-backup
+telemetry-transfer

--- a/e2e-tests/tests/demand-backup/01-assert.yaml
+++ b/e2e-tests/tests/demand-backup/01-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 300
+timeout: 480
 ---
 kind: StatefulSet
 apiVersion: apps/v1

--- a/e2e-tests/tests/demand-backup/04-assert.yaml
+++ b/e2e-tests/tests/demand-backup/04-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 300
+timeout: 560
 ---
 kind: Job
 apiVersion: batch/v1

--- a/e2e-tests/tests/scheduled-backup/05-assert.yaml
+++ b/e2e-tests/tests/scheduled-backup/05-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 500
+timeout: 600
 ---
 kind: CronJob
 apiVersion: batch/v1

--- a/e2e-tests/tests/start-from-backup/01-assert.yaml
+++ b/e2e-tests/tests/start-from-backup/01-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 360
+timeout: 480
 ---
 kind: StatefulSet
 apiVersion: apps/v1


### PR DESCRIPTION
[![K8SPG-302](https://badgen.net/badge/JIRA/K8SPG-302/green)](https://jira.percona.com/browse/K8SPG-302) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Change:**
*Some timeouts were too low for minikube and this also adds `run-minikube.csv` file with the list of tests which are supported on minikube and which will be used from parametrized pipeline.
`monitoring` test was not added because it is using LoadBalancer which minikube doesn't support.*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PG version?
- [x] Does the change support oldest and newest supported Kubernetes version?