### PR TITLE
K8SPG-397 Added gke_gcloud_auth_plugin_cache and kubeconfig in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ bin/
 *.test
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+kubeconfig
+gke_gcloud_auth_plugin_cache


### PR DESCRIPTION
[![K8SPG-397](https://badgen.net/badge/JIRA/K8SPG-397/green)](https://jira.percona.com/browse/K8SPG-397) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
When I clone the repo and run some test with kuttl framework, two local file are created: `kubeconfig` and `gke_gcloud_auth_plugin_cache` which are needed for the proper operation of the `kubectl` and `gcloud` commands. However, those files are being listed as `Untracked files` by git, but they are not meant to be committed in the repo.

**Solution:**
I added them in the `.gitignore` file.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?