### PR TITLE
K8SPG-420: Fix unpause problems

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ void CreateCluster(String CLUSTER_SUFFIX) {
                 ret_val=0
                 gcloud auth activate-service-account --key-file $CLIENT_SECRET_FILE
                 gcloud config set project $GCP_PROJECT
-                gcloud container clusters create --zone=${GKERegion} $CLUSTER_NAME-${CLUSTER_SUFFIX} --cluster-version=1.21 --machine-type=n1-standard-4 --preemptible --num-nodes=3 --network=jenkins-pg-vpc --subnetwork=jenkins-pg-${CLUSTER_SUFFIX} --no-enable-autoupgrade --cluster-ipv4-cidr=/21 --labels delete-cluster-after-hours=6 && \
+                gcloud container clusters create --zone=${GKERegion} $CLUSTER_NAME-${CLUSTER_SUFFIX} --cluster-version=1.24 --machine-type=n1-standard-4 --preemptible --num-nodes=3 --network=jenkins-pg-vpc --subnetwork=jenkins-pg-${CLUSTER_SUFFIX} --no-enable-autoupgrade --cluster-ipv4-cidr=/21 --labels delete-cluster-after-hours=6 && \
                 kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user jenkins@"$GCP_PROJECT".iam.gserviceaccount.com || ret_val=\$?
                 if [ \${ret_val} -eq 0 ]; then break; fi
                 ret_num=\$((ret_num + 1))

--- a/internal/controller/pod/inithandler.go
+++ b/internal/controller/pod/inithandler.go
@@ -173,6 +173,12 @@ func (c *Controller) handleBootstrapInit(newPod *apiv1.Pod, cluster *crv1.Pgclus
 	// create the pgBackRest stanza
 	backrestoperator.StanzaCreate(newPod.ObjectMeta.Namespace, clusterName, c.Client)
 
+	// now scale any replicas deployments to 1
+	_, err := clusteroperator.ScaleClusterDeployments(c.Client, *cluster, 1, false, true, false, false)
+	if err != nil {
+		log.Error(err)
+	}
+
 	// if this is a pgbouncer enabled cluster, add a pgbouncer
 	// Note: we only warn if we cannot create the pgBouncer, so eecution can
 	// continue

--- a/internal/operator/cluster/clusterlogic.go
+++ b/internal/operator/cluster/clusterlogic.go
@@ -727,7 +727,7 @@ func ScaleClusterDeployments(clientset kubernetes.Interface, cluster crv1.Pgclus
 	}
 
 	for _, deployment := range deploymentList.Items {
-		_replicas := replicas
+		replicas := replicas
 
 		// determine if the deployment is a primary, replica, or supporting service (pgBackRest,
 		// pgBouncer, etc.)
@@ -747,7 +747,7 @@ func ScaleClusterDeployments(clientset kubernetes.Interface, cluster crv1.Pgclus
 			// if the replica total is greater than 0, set number of pgBouncer
 			// replicas to the number that is specified in the cluster entry
 			if replicas > 0 {
-				_replicas = int(cluster.Spec.PgBouncer.Replicas)
+				replicas = int(cluster.Spec.PgBouncer.Replicas)
 			}
 		case deployment.Labels[config.LABEL_PGO_BACKREST_REPO] == "true":
 			clusterInfo.PGBackRestRepoDeployment = deployment.Name
@@ -764,19 +764,19 @@ func ScaleClusterDeployments(clientset kubernetes.Interface, cluster crv1.Pgclus
 			}
 		}
 
-		log.Debugf("scaling deployment %s to %d for cluster %s", deployment.Name, _replicas,
+		log.Debugf("scaling deployment %s to %d for cluster %s", deployment.Name, replicas,
 			clusterName)
 
 		// Scale the deployment according to the number of replicas specified.  If an error is
 		// encountered, log it and move on to scaling the next deployment
-		patch, err := kubeapi.NewMergePatch().Add("spec", "replicas")(_replicas).Bytes()
+		patch, err := kubeapi.NewMergePatch().Add("spec", "replicas")(replicas).Bytes()
 		if err == nil {
 			log.Debugf("patching deployment %s: %s", deployment.GetName(), patch)
 			_, err = clientset.AppsV1().Deployments(namespace).
 				Patch(ctx, deployment.GetName(), types.MergePatchType, patch, metav1.PatchOptions{})
 		}
 		if err != nil {
-			log.Errorf("Error scaling deployment %s to %d: %v", deployment.Name, _replicas, err)
+			log.Errorf("Error scaling deployment %s to %d: %v", deployment.Name, replicas, err)
 		}
 	}
 	return


### PR DESCRIPTION
[![K8SPG-420](https://badgen.net/badge/JIRA/K8SPG-420/green)](https://jira.percona.com/browse/K8SPG-420) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
There are two problems after unpausing the cluster:
1. Replica deployments are not scaled up
2. On certain control planes (i.e. k3d v5.5.2) backrest repo pods scaled up incorrectly

**Cause:**
1.  An implementation problem. Crunchy controller didn't implement scaling up replicas after starting up from shutdown.
2. A bug. If pgbouncer deployment is processed before backrest deployment, the bug happens.

**Solution:**
1. Implement.
2. Fix.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PG version?
- [x] Does the change support oldest and newest supported Kubernetes version?