### PR TITLE
CLOUD-808 Fix PMM server deployment in tests

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -84,7 +84,7 @@ get_cr() {
 		| '$(printf .spec.image="%s" \"${IMAGE_POSTGRESQL}\")'
 		| '$(printf .spec.backups.pgbackrest.image="%s" \"${IMAGE_BACKREST}\")'
 		| '$(printf .spec.proxy.pgBouncer.image="%s" \"${IMAGE_PGBOUNCER}\")'
-		| '$(printf .spec.pmm.image="%s" \"${IMAGE_PMM}\")'
+		| '$(printf .spec.pmm.image="%s" \"${IMAGE_PMM_CLIENT}\")'
 		| '$(printf .spec.pmm.secret="%s" \"${test_name}-pmm-secret\")'
 		' "${DEPLOY_DIR}/cr.yaml" \
 		>"${TEMP_DIR}/cr.yaml"
@@ -240,8 +240,8 @@ wait_for_delete() {
 deploy_pmm_server() {
 	local platform=kubernetes
 	helm uninstall -n "${NAMESPACE}" pmm || :
-	helm install monitoring -n "${NAMESPACE}" --set imageTag=$IMAGE_PMM_SERVER_TAG --set service.type="LoadBalancer" \
-		--set imageRepo=$IMAGE_PMM_SERVER_REPO --set platform="${platform}" "https://percona-charts.storage.googleapis.com/pmm-server-${PMM_SERVER_VERSION}.tgz"
+	helm install monitoring -n "${NAMESPACE}" --set imageTag=${IMAGE_PMM_SERVER#*:} --set service.type="LoadBalancer" \
+		--set imageRepo=${IMAGE_PMM_SERVER%:*} --set platform="${platform}" "https://percona-charts.storage.googleapis.com/pmm-server-${PMM_SERVER_VERSION}.tgz"
 }
 
 generate_pmm_api_key() {

--- a/e2e-tests/vars.sh
+++ b/e2e-tests/vars.sh
@@ -18,10 +18,9 @@ export IMAGE_POSTGRESQL=${IMAGE_POSTGRESQL:-"${IMAGE_BASE}:main-ppg$PG_VER-postg
 export IMAGE_BACKREST=${IMAGE_BACKREST:-"${IMAGE_BASE}:main-ppg$PG_VER-pgbackrest"}
 export IMAGE_PGBADGER=${IMAGE_PGBADGER:-"${IMAGE_BASE}:main-ppg$PG_VER-pgbadger"}
 export BUCKET=${BUCKET:-"pg-operator-testing"}
-export IMAGE_PMM=${IMAGE_PMM:-"perconalab/pmm-client:dev-latest"}
 export PMM_SERVER_VERSION=${PMM_SERVER_VERSION:-"9.9.9"}
-export IMAGE_PMM_SERVER_REPO=${IMAGE_PMM_SERVER_REPO:-"perconalab/pmm-server"}
-export IMAGE_PMM_SERVER_TAG=${IMAGE_PMM_SERVER_TAG:-"dev-latest"}
+export IMAGE_PMM_CLIENT=${IMAGE_PMM_CLIENT:-"perconalab/pmm-client:dev-latest"}
+export IMAGE_PMM_SERVER=${IMAGE_PMM_SERVER:-"perconalab/pmm-server:dev-latest"}
 
 date=$(which gdate || which date)
 sed=$(which gsed || which sed)


### PR DESCRIPTION
[![CLOUD-808](https://badgen.net/badge/JIRA/CLOUD-808/green)](https://jira.percona.com/browse/CLOUD-808) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
- Combine IMAGE_PMM_SERVER_REPO and IMAGE_PMM_SERVER_TAG parameters in Jenkins pipelines into one IMAGE_PMM_SERVER (it's just excessive copy pasting, all the other images we have only one parameter for both)
- Rename IMAGE_PMM to IMAGE_PMM_CLIENT

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?