### PR TITLE
CLOUD-812 Fix monitoring test case for PG operator which fails due to assert for PMM server creation

### DIFF
--- a/e2e-tests/tests/monitoring/01-assert.yaml
+++ b/e2e-tests/tests/monitoring/01-assert.yaml
@@ -14,17 +14,7 @@ status:
   replicas: 1
   updatedReplicas: 1
 ---
+kind: Service
 apiVersion: v1
-count: 1
-involvedObject:
-  apiVersion: v1
-  kind: Service
+metadata:
   name: monitoring-service
-kind: Event
-message: Ensured load balancer
-reason: EnsuredLoadBalancer
-reportingComponent: ""
-reportingInstance: ""
-source:
-  component: service-controller
-type: Normal

--- a/e2e-tests/tests/monitoring/01-assert.yaml
+++ b/e2e-tests/tests/monitoring/01-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 120
+timeout: 480
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -14,6 +14,11 @@ status:
   replicas: 1
   updatedReplicas: 1
 ---
+kind: Service
+apiVersion: v1
+metadata:
+  name: monitoring-service
+---
 apiVersion: v1
 count: 1
 involvedObject:
@@ -23,8 +28,6 @@ involvedObject:
 kind: Event
 message: Ensured load balancer
 reason: EnsuredLoadBalancer
-reportingComponent: ""
-reportingInstance: ""
 source:
   component: service-controller
 type: Normal

--- a/e2e-tests/tests/monitoring/01-assert.yaml
+++ b/e2e-tests/tests/monitoring/01-assert.yaml
@@ -14,7 +14,17 @@ status:
   replicas: 1
   updatedReplicas: 1
 ---
-kind: Service
 apiVersion: v1
-metadata:
+count: 1
+involvedObject:
+  apiVersion: v1
+  kind: Service
   name: monitoring-service
+kind: Event
+message: Ensured load balancer
+reason: EnsuredLoadBalancer
+reportingComponent: ""
+reportingInstance: ""
+source:
+  component: service-controller
+type: Normal

--- a/e2e-tests/tests/monitoring/03-assert.yaml
+++ b/e2e-tests/tests/monitoring/03-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 180
+timeout: 240
 ---
 apiVersion: pgv2.percona.com/v2
 kind: PerconaPGCluster

--- a/e2e-tests/tests/monitoring/03-assert.yaml
+++ b/e2e-tests/tests/monitoring/03-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 180
+timeout: 200
 ---
 apiVersion: pgv2.percona.com/v2
 kind: PerconaPGCluster

--- a/e2e-tests/tests/monitoring/03-assert.yaml
+++ b/e2e-tests/tests/monitoring/03-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 200
+timeout: 180
 ---
 apiVersion: pgv2.percona.com/v2
 kind: PerconaPGCluster

--- a/e2e-tests/vars.sh
+++ b/e2e-tests/vars.sh
@@ -16,7 +16,6 @@ export PG_VER="${PG_VER:-16}"
 export IMAGE_PGBOUNCER=${IMAGE_PGBOUNCER:-"${IMAGE_BASE}:main-ppg$PG_VER-pgbouncer"}
 export IMAGE_POSTGRESQL=${IMAGE_POSTGRESQL:-"${IMAGE_BASE}:main-ppg$PG_VER-postgres"}
 export IMAGE_BACKREST=${IMAGE_BACKREST:-"${IMAGE_BASE}:main-ppg$PG_VER-pgbackrest"}
-export IMAGE_PGBADGER=${IMAGE_PGBADGER:-"${IMAGE_BASE}:main-ppg$PG_VER-pgbadger"}
 export BUCKET=${BUCKET:-"pg-operator-testing"}
 export PMM_SERVER_VERSION=${PMM_SERVER_VERSION:-"9.9.9"}
 export IMAGE_PMM_CLIENT=${IMAGE_PMM_CLIENT:-"perconalab/pmm-client:dev-latest"}


### PR DESCRIPTION
[![CLOUD-812](https://badgen.net/badge/JIRA/CLOUD-812/green)](https://jira.percona.com/browse/CLOUD-812) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
`monitoring` test case was failing

**Cause:** & **Solution:**
- The assert yaml file for the install-PMM-server step has to be updated
- The timeout of the create-cluster assert step has to be increased, too, because it didn't wait long enough for the PG cluster to be created and was failing prematurely.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?