### PR TITLE
K8SPG-430: Add labels to backup objects

### DIFF
--- a/internal/naming/labels.go
+++ b/internal/naming/labels.go
@@ -185,7 +185,7 @@ func PGBackRestLabels(clusterName string) labels.Set {
 // PGBackRestBackupJobLabels provides labels for pgBackRest backup Jobs.
 func PGBackRestBackupJobLabels(clusterName, repoName string,
 	backupType BackupJobType) labels.Set {
-	repoLabels := PGBackRestLabels(clusterName)
+	repoLabels := WithPerconaLabels(PGBackRestLabels(clusterName), clusterName, "")
 	jobLabels := map[string]string{
 		LabelPGBackRestRepo:   repoName,
 		LabelPGBackRestBackup: string(backupType),
@@ -206,7 +206,7 @@ func PGBackRestBackupJobSelector(clusterName, repoName string,
 // Deprecated: Store restore data in the pgBackRest ConfigMap and Secret,
 // [PGBackRestConfig] and [PGBackRestSecret].
 func PGBackRestRestoreConfigLabels(clusterName string) labels.Set {
-	commonLabels := PGBackRestLabels(clusterName)
+	commonLabels := WithPerconaLabels(PGBackRestLabels(clusterName), clusterName, "")
 	jobLabels := map[string]string{
 		LabelPGBackRestRestoreConfig: "",
 	}
@@ -222,7 +222,7 @@ func PGBackRestRestoreConfigSelector(clusterName string) labels.Selector {
 // PGBackRestRestoreJobLabels provides labels for pgBackRest restore Jobs and
 // associated configuration ConfigMaps and Secrets.
 func PGBackRestRestoreJobLabels(clusterName string) labels.Set {
-	commonLabels := PGBackRestLabels(clusterName)
+	commonLabels := WithPerconaLabels(PGBackRestLabels(clusterName), clusterName, "")
 	jobLabels := map[string]string{
 		LabelPGBackRestRestore: "",
 	}
@@ -237,7 +237,7 @@ func PGBackRestRestoreJobSelector(clusterName string) labels.Selector {
 // PGBackRestRepoLabels provides common labels for pgBackRest repository
 // resources.
 func PGBackRestRepoLabels(clusterName, repoName string) labels.Set {
-	commonLabels := PGBackRestLabels(clusterName)
+	commonLabels := WithPerconaLabels(PGBackRestLabels(clusterName), clusterName, "")
 	repoLabels := map[string]string{
 		LabelPGBackRestRepo: repoName,
 	}
@@ -253,7 +253,7 @@ func PGBackRestSelector(clusterName string) labels.Selector {
 // PGBackRestConfigLabels provides labels for the pgBackRest configuration created and used by
 // the PostgreSQL Operator
 func PGBackRestConfigLabels(clusterName string) labels.Set {
-	repoLabels := PGBackRestLabels(clusterName)
+	repoLabels := WithPerconaLabels(PGBackRestLabels(clusterName), clusterName, "")
 	operatorConfigLabels := map[string]string{
 		LabelPGBackRestConfig: "",
 	}
@@ -262,7 +262,7 @@ func PGBackRestConfigLabels(clusterName string) labels.Set {
 
 // PGBackRestCronJobLabels provides common labels for pgBackRest CronJobs
 func PGBackRestCronJobLabels(clusterName, repoName, backupType string) labels.Set {
-	commonLabels := PGBackRestLabels(clusterName)
+	commonLabels := WithPerconaLabels(PGBackRestLabels(clusterName), clusterName, "")
 	cronJobLabels := map[string]string{
 		LabelPGBackRestRepo:    repoName,
 		LabelPGBackRestCronJob: backupType,
@@ -272,7 +272,7 @@ func PGBackRestCronJobLabels(clusterName, repoName, backupType string) labels.Se
 
 // PGBackRestDedicatedLabels provides labels for a pgBackRest dedicated repository host
 func PGBackRestDedicatedLabels(clusterName string) labels.Set {
-	commonLabels := PGBackRestLabels(clusterName)
+	commonLabels := WithPerconaLabels(PGBackRestLabels(clusterName), clusterName, "")
 	operatorConfigLabels := map[string]string{
 		LabelPGBackRestDedicated: "",
 	}

--- a/internal/naming/labels_test.go
+++ b/internal/naming/labels_test.go
@@ -149,7 +149,7 @@ func TestPGBackRestLabelFuncs(t *testing.T) {
 	repoName := "hippo-repo"
 
 	// verify the labels that identify pgBackRest resources
-	pgBackRestLabels := PGBackRestLabels(clusterName)
+	pgBackRestLabels := WithPerconaLabels(PGBackRestLabels(clusterName), clusterName, "")
 	assert.Equal(t, pgBackRestLabels.Get(LabelCluster), clusterName)
 	assert.Check(t, pgBackRestLabels.Has(LabelPGBackRest))
 


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
Labels not aligned for backup objects (repo sts, jobs, and repo PVC).

**Solution:**
Add missing labels

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PG version?
- [x] Does the change support oldest and newest supported Kubernetes version?
