### PR TITLE
K8SPG-430: Add labels only for 2.3.0 and above

### DIFF
--- a/internal/controller/postgrescluster/cluster.go
+++ b/internal/controller/postgrescluster/cluster.go
@@ -49,7 +49,7 @@ func (r *Reconciler) reconcileClusterConfigMap(
 	clusterConfigMap.Labels = naming.Merge(cluster.Spec.Metadata.GetLabelsOrNil(),
 		naming.WithPerconaLabels(map[string]string{
 			naming.LabelCluster: cluster.Name,
-		}, cluster.Name, ""))
+		}, cluster.Name, "", cluster.Labels[naming.LabelVersion]))
 
 	if err == nil {
 		err = patroni.ClusterConfigMap(ctx, cluster, pgHBAs, pgParameters,
@@ -78,7 +78,7 @@ func (r *Reconciler) reconcileClusterPodService(
 	clusterPodService.Labels = naming.Merge(cluster.Spec.Metadata.GetLabelsOrNil(),
 		naming.WithPerconaLabels(map[string]string{
 			naming.LabelCluster: cluster.Name,
-		}, cluster.Name, "pg"))
+		}, cluster.Name, "pg", cluster.Labels[naming.LabelVersion]))
 
 	// Allocate no IP address (headless) and match any Pod with the cluster
 	// label, regardless of its readiness. Not particularly useful by itself, but
@@ -121,7 +121,7 @@ func (r *Reconciler) generateClusterPrimaryService(
 		naming.WithPerconaLabels(map[string]string{
 			naming.LabelCluster: cluster.Name,
 			naming.LabelRole:    naming.RolePrimary,
-		}, cluster.Name, "pg"))
+		}, cluster.Name, "pg", cluster.Labels[naming.LabelVersion]))
 
 	err := errors.WithStack(r.setControllerReference(cluster, service))
 
@@ -206,7 +206,7 @@ func (r *Reconciler) generateClusterReplicaService(
 		naming.WithPerconaLabels(map[string]string{
 			naming.LabelCluster: cluster.Name,
 			naming.LabelRole:    naming.RoleReplica,
-		}, cluster.Name, "pg"))
+		}, cluster.Name, "pg", cluster.Labels[naming.LabelVersion]))
 
 	// Allocate an IP address and let Kubernetes manage the Endpoints by
 	// selecting Pods with the Patroni replica role.

--- a/internal/controller/postgrescluster/cluster_test.go
+++ b/internal/controller/postgrescluster/cluster_test.go
@@ -607,6 +607,10 @@ func TestGenerateClusterPrimaryService(t *testing.T) {
 	cluster.Name = "pg5"
 	cluster.Spec.Port = initialize.Int32(2600)
 
+	cluster.Labels = map[string]string{
+		naming.LabelVersion: "2.3.0",
+	}
+
 	leader := &corev1.Service{}
 	leader.Spec.ClusterIP = "1.9.8.3"
 
@@ -738,6 +742,10 @@ func TestGenerateClusterReplicaServiceIntent(t *testing.T) {
 	cluster.Namespace = "ns1"
 	cluster.Name = "pg2"
 	cluster.Spec.Port = initialize.Int32(9876)
+
+	cluster.Labels = map[string]string{
+		naming.LabelVersion: "2.3.0",
+	}
 
 	service, err := reconciler.generateClusterReplicaService(cluster)
 	assert.NilError(t, err)

--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -1162,7 +1162,7 @@ func generateInstanceStatefulSetIntent(_ context.Context,
 			naming.LabelInstanceSet: spec.Name,
 			naming.LabelInstance:    sts.Name,
 			naming.LabelData:        naming.DataPostgres,
-		}, cluster.Name, "pg"))
+		}, cluster.Name, "pg", cluster.Labels[naming.LabelVersion]))
 	sts.Spec.Selector = &metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			naming.LabelCluster:     cluster.Name,
@@ -1182,7 +1182,7 @@ func generateInstanceStatefulSetIntent(_ context.Context,
 			naming.LabelInstanceSet: spec.Name,
 			naming.LabelInstance:    sts.Name,
 			naming.LabelData:        naming.DataPostgres,
-		}, cluster.Name, "pg"))
+		}, cluster.Name, "pg", cluster.Labels[naming.LabelVersion]))
 
 	// Don't clutter the namespace with extra ControllerRevisions.
 	// The "controller-revision-hash" label still exists on the Pod.
@@ -1309,7 +1309,7 @@ func (r *Reconciler) reconcileInstanceConfigMap(
 			naming.LabelCluster:     cluster.Name,
 			naming.LabelInstanceSet: spec.Name,
 			naming.LabelInstance:    instance.Name,
-		}, cluster.Name, "pg"))
+		}, cluster.Name, "pg", cluster.Labels[naming.LabelVersion]))
 
 	if err == nil {
 		err = patroni.InstanceConfigMap(ctx, cluster, spec, instanceConfigMap)
@@ -1355,7 +1355,7 @@ func (r *Reconciler) reconcileInstanceCertificates(
 			naming.LabelCluster:     cluster.Name,
 			naming.LabelInstanceSet: spec.Name,
 			naming.LabelInstance:    instance.Name,
-		}, cluster.Name, ""))
+		}, cluster.Name, "", cluster.Labels[naming.LabelVersion]))
 
 	// This secret is holding certificates, but the "kubernetes.io/tls" type
 	// expects an *unencrypted* private key. We're also adding other values and

--- a/internal/controller/postgrescluster/patroni.go
+++ b/internal/controller/postgrescluster/patroni.go
@@ -164,7 +164,7 @@ func (r *Reconciler) reconcilePatroniDistributedConfiguration(
 		naming.WithPerconaLabels(map[string]string{
 			naming.LabelCluster: cluster.Name,
 			naming.LabelPatroni: naming.PatroniScope(cluster),
-		}, cluster.Name, ""))
+		}, cluster.Name, "", cluster.Labels[naming.LabelVersion]))
 
 	// Allocate no IP address (headless) and create no Endpoints.
 	// - https://docs.k8s.io/concepts/services-networking/service/#headless-services
@@ -251,7 +251,7 @@ func (r *Reconciler) generatePatroniLeaderLeaseService(
 		naming.WithPerconaLabels(map[string]string{
 			naming.LabelCluster: cluster.Name,
 			naming.LabelPatroni: naming.PatroniScope(cluster),
-		}, cluster.Name, ""))
+		}, cluster.Name, "", cluster.Labels[naming.LabelVersion]))
 
 	// Allocate an IP address and/or node port and let Patroni manage the Endpoints.
 	// Patroni will ensure that they always route to the elected leader.
@@ -407,7 +407,7 @@ func (r *Reconciler) reconcileReplicationSecret(
 		naming.WithPerconaLabels(map[string]string{
 			naming.LabelCluster:            cluster.Name,
 			naming.LabelClusterCertificate: "replication-client-tls",
-		}, cluster.Name, ""))
+		}, cluster.Name, "", cluster.Labels[naming.LabelVersion]))
 
 	// K8SPG-330: Keep this commented in case of conflicts.
 	// We don't want to delete TLS secrets on cluster deletion.

--- a/internal/controller/postgrescluster/patroni_test.go
+++ b/internal/controller/postgrescluster/patroni_test.go
@@ -124,7 +124,7 @@ ownerReferences:
 			"b": "v2",
 			"postgres-operator.crunchydata.com/cluster": "pg2",
 			"postgres-operator.crunchydata.com/patroni": "pg2-ha",
-		}, "pg2", "")))
+		}, "pg2", "", "2.3.0")))
 
 		// Labels not in the selector.
 		assert.Assert(t, service.Spec.Selector == nil,
@@ -154,7 +154,7 @@ ownerReferences:
 			"d": "v4",
 			"postgres-operator.crunchydata.com/cluster": "pg2",
 			"postgres-operator.crunchydata.com/patroni": "pg2-ha",
-		}, "pg2", "")))
+		}, "pg2", "", "2.3.0")))
 
 		// Labels not in the selector.
 		assert.Assert(t, service.Spec.Selector == nil,

--- a/internal/controller/postgrescluster/patroni_test.go
+++ b/internal/controller/postgrescluster/patroni_test.go
@@ -59,6 +59,10 @@ func TestGeneratePatroniLeaderLeaseService(t *testing.T) {
 	cluster.Name = "pg2"
 	cluster.Spec.Port = initialize.Int32(9876)
 
+	cluster.Labels = map[string]string{
+		naming.LabelVersion: "2.3.0",
+	}
+
 	alwaysExpect := func(t testing.TB, service *corev1.Service) {
 		assert.Assert(t, marshalMatches(service.TypeMeta, `
 apiVersion: v1
@@ -109,6 +113,9 @@ ownerReferences:
 		cluster.Spec.Metadata = &v1beta1.Metadata{
 			Annotations: map[string]string{"a": "v1"},
 			Labels:      map[string]string{"b": "v2"},
+		}
+		cluster.Labels = map[string]string{
+			naming.LabelVersion: "2.3.0",
 		}
 
 		service, err := reconciler.generatePatroniLeaderLeaseService(cluster)

--- a/internal/controller/postgrescluster/pgadmin.go
+++ b/internal/controller/postgrescluster/pgadmin.go
@@ -84,7 +84,7 @@ func (r *Reconciler) generatePGAdminConfigMap(
 		naming.WithPerconaLabels(map[string]string{
 			naming.LabelCluster: cluster.Name,
 			naming.LabelRole:    naming.RolePGAdmin,
-		}, cluster.Name, ""))
+		}, cluster.Name, "", cluster.Labels[naming.LabelVersion]))
 
 	err := errors.WithStack(pgadmin.ConfigMap(cluster, configmap))
 	if err == nil {
@@ -151,7 +151,7 @@ func (r *Reconciler) generatePGAdminService(
 		naming.WithPerconaLabels(map[string]string{
 			naming.LabelCluster: cluster.Name,
 			naming.LabelRole:    naming.RolePGAdmin,
-		}, cluster.Name, ""))
+		}, cluster.Name, "", cluster.Labels[naming.LabelVersion]))
 
 	// Allocate an IP address and/or node port and let Kubernetes manage the
 	// Endpoints by selecting Pods with the pgAdmin role.
@@ -259,7 +259,7 @@ func (r *Reconciler) reconcilePGAdminStatefulSet(
 			naming.LabelCluster: cluster.Name,
 			naming.LabelRole:    naming.RolePGAdmin,
 			naming.LabelData:    naming.DataPGAdmin,
-		}, cluster.Name, ""))
+		}, cluster.Name, "", cluster.Labels[naming.LabelVersion]))
 	sts.Spec.Selector = &metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			naming.LabelCluster: cluster.Name,
@@ -276,7 +276,7 @@ func (r *Reconciler) reconcilePGAdminStatefulSet(
 			naming.LabelCluster: cluster.Name,
 			naming.LabelRole:    naming.RolePGAdmin,
 			naming.LabelData:    naming.DataPGAdmin,
-		}, cluster.Name, ""))
+		}, cluster.Name, "", cluster.Labels[naming.LabelVersion]))
 
 	// if the shutdown flag is set, set pgAdmin replicas to 0
 	if cluster.Spec.Shutdown != nil && *cluster.Spec.Shutdown {
@@ -383,7 +383,7 @@ func (r *Reconciler) reconcilePGAdminDataVolume(
 	)
 	pvc.Labels = naming.Merge(
 		cluster.Spec.Metadata.GetLabelsOrNil(),
-		naming.WithPerconaLabels(labelMap, cluster.Name, ""),
+		naming.WithPerconaLabels(labelMap, cluster.Name, "", cluster.Labels[naming.LabelVersion]),
 	)
 	pvc.Spec = cluster.Spec.UserInterface.PGAdmin.DataVolumeClaimSpec
 

--- a/internal/controller/postgrescluster/pgadmin_test.go
+++ b/internal/controller/postgrescluster/pgadmin_test.go
@@ -131,7 +131,7 @@ ownerReferences:
 			"c": "v7", "d": "v4", "f": "v8",
 			"postgres-operator.crunchydata.com/cluster": "pg1",
 			"postgres-operator.crunchydata.com/role":    "pgadmin",
-		}, "pg1", "")))
+		}, "pg1", "", "2.3.0")))
 	})
 }
 
@@ -225,7 +225,7 @@ ownerReferences:
 			"b": "v2",
 			"postgres-operator.crunchydata.com/cluster": "my-cluster",
 			"postgres-operator.crunchydata.com/role":    "pgadmin",
-		}, "my-cluster", "")))
+		}, "my-cluster", "", "2.3.0")))
 
 		// Labels not in the selector.
 		assert.DeepEqual(t, service.Spec.Selector, map[string]string{
@@ -258,7 +258,7 @@ ownerReferences:
 			"d": "v4",
 			"postgres-operator.crunchydata.com/cluster": "my-cluster",
 			"postgres-operator.crunchydata.com/role":    "pgadmin",
-		}, "my-cluster", "")))
+		}, "my-cluster", "", "2.3.0")))
 
 		// Labels not in the selector.
 		assert.DeepEqual(t, service.Spec.Selector, map[string]string{

--- a/internal/controller/postgrescluster/pgadmin_test.go
+++ b/internal/controller/postgrescluster/pgadmin_test.go
@@ -52,6 +52,10 @@ func TestGeneratePGAdminConfigMap(t *testing.T) {
 	cluster.Namespace = "some-ns"
 	cluster.Name = "pg1"
 
+	cluster.Labels = map[string]string{
+		naming.LabelVersion: "2.3.0",
+	}
+
 	t.Run("Unspecified", func(t *testing.T) {
 		for _, spec := range []*v1beta1.UserInterfaceSpec{
 			nil, new(v1beta1.UserInterfaceSpec),
@@ -147,6 +151,10 @@ func TestGeneratePGAdminService(t *testing.T) {
 	cluster := &v1beta1.PostgresCluster{}
 	cluster.Namespace = "my-ns"
 	cluster.Name = "my-cluster"
+
+	cluster.Labels = map[string]string{
+		naming.LabelVersion: "2.3.0",
+	}
 
 	t.Run("Unspecified", func(t *testing.T) {
 		for _, spec := range []*v1beta1.UserInterfaceSpec{
@@ -483,6 +491,10 @@ func TestReconcilePGAdminStatefulSet(t *testing.T) {
 	ns := setupNamespace(t, cc)
 	cluster := pgAdminTestCluster(*ns)
 
+	cluster.Labels = map[string]string{
+		naming.LabelVersion: "2.3.0",
+	}
+
 	assert.NilError(t, cc.Create(ctx, cluster))
 	t.Cleanup(func() { assert.Check(t, cc.Delete(ctx, cluster)) })
 
@@ -552,6 +564,9 @@ terminationGracePeriodSeconds: 30
 	t.Run("verify customized deployment", func(t *testing.T) {
 
 		customcluster := pgAdminTestCluster(*ns)
+		customcluster.Labels = map[string]string{
+			naming.LabelVersion: "2.3.0",
+		}
 
 		// add pod level customizations
 		customcluster.Name = "custom-cluster"

--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -493,7 +493,8 @@ func (r *Reconciler) generateRepoHostIntent(postgresCluster *v1beta1.PostgresClu
 	labels := naming.Merge(
 		postgresCluster.Spec.Metadata.GetLabelsOrNil(),
 		postgresCluster.Spec.Backups.PGBackRest.Metadata.GetLabelsOrNil(),
-		naming.PGBackRestDedicatedLabels(postgresCluster.GetName()),
+		naming.WithPerconaLabels(naming.PGBackRestDedicatedLabels(postgresCluster.GetName()),
+			postgresCluster.GetName(), "", postgresCluster.Labels[naming.LabelVersion]),
 		map[string]string{
 			naming.LabelData: naming.DataPGBackRest,
 		})
@@ -638,7 +639,9 @@ func (r *Reconciler) generateRepoVolumeIntent(postgresCluster *v1beta1.PostgresC
 	labels := naming.Merge(
 		postgresCluster.Spec.Metadata.GetLabelsOrNil(),
 		postgresCluster.Spec.Backups.PGBackRest.Metadata.GetLabelsOrNil(),
-		naming.PGBackRestRepoVolumeLabels(postgresCluster.GetName(), repoName),
+		naming.WithPerconaLabels(
+			naming.PGBackRestRepoVolumeLabels(postgresCluster.GetName(), repoName),
+			postgresCluster.GetName(), "", postgresCluster.Labels[naming.LabelVersion]),
 	)
 
 	// generate the default metadata
@@ -1194,7 +1197,9 @@ func (r *Reconciler) generateRestoreJobIntent(cluster *v1beta1.PostgresCluster,
 	labels := naming.Merge(
 		cluster.Spec.Metadata.GetLabelsOrNil(),
 		cluster.Spec.Backups.PGBackRest.Metadata.GetLabelsOrNil(),
-		naming.PGBackRestRestoreJobLabels(cluster.Name),
+		naming.WithPerconaLabels(
+			naming.PGBackRestRestoreJobLabels(cluster.Name),
+			cluster.Name, "", cluster.Labels[naming.LabelVersion]),
 		map[string]string{naming.LabelStartupInstance: instanceName},
 	)
 	meta.Annotations = annotations
@@ -1727,7 +1732,9 @@ func (r *Reconciler) copyRestoreConfiguration(ctx context.Context,
 	config.Labels = naming.Merge(
 		cluster.Spec.Metadata.GetLabelsOrNil(),
 		cluster.Spec.Backups.PGBackRest.Metadata.GetLabelsOrNil(),
-		naming.PGBackRestConfigLabels(cluster.GetName()),
+		naming.WithPerconaLabels(
+			naming.PGBackRestConfigLabels(cluster.GetName()),
+			cluster.GetName(), "", cluster.Labels[naming.LabelVersion]),
 	)
 	if err == nil {
 		err = r.setControllerReference(cluster, config)
@@ -1745,7 +1752,9 @@ func (r *Reconciler) copyRestoreConfiguration(ctx context.Context,
 	secret.Labels = naming.Merge(
 		cluster.Spec.Metadata.GetLabelsOrNil(),
 		cluster.Spec.Backups.PGBackRest.Metadata.GetLabelsOrNil(),
-		naming.PGBackRestConfigLabels(cluster.Name),
+		naming.WithPerconaLabels(
+			naming.PGBackRestConfigLabels(cluster.Name),
+			cluster.Name, "", cluster.Labels[naming.LabelVersion]),
 	)
 	if err == nil {
 		err = r.setControllerReference(cluster, secret)
@@ -1827,7 +1836,9 @@ func (r *Reconciler) copyConfigurationResources(ctx context.Context, cluster,
 				cluster.Spec.Metadata.GetLabelsOrNil(),
 				cluster.Spec.Backups.PGBackRest.Metadata.GetLabelsOrNil(),
 				// this label allows for cleanup when the restore completes
-				naming.PGBackRestRestoreJobLabels(cluster.Name),
+				naming.WithPerconaLabels(
+					naming.PGBackRestRestoreJobLabels(cluster.Name),
+					cluster.Name, "", cluster.Labels[naming.LabelVersion]),
 			)
 			if err := r.setControllerReference(cluster, secretCopy); err != nil {
 				return err
@@ -1881,7 +1892,9 @@ func (r *Reconciler) copyConfigurationResources(ctx context.Context, cluster,
 				cluster.Spec.Metadata.GetLabelsOrNil(),
 				cluster.Spec.Backups.PGBackRest.Metadata.GetLabelsOrNil(),
 				// this label allows for cleanup when the restore completes
-				naming.PGBackRestRestoreJobLabels(cluster.Name),
+				naming.WithPerconaLabels(
+					naming.PGBackRestRestoreJobLabels(cluster.Name),
+					cluster.Name, "", cluster.Labels[naming.LabelVersion]),
 			)
 			if err := r.setControllerReference(cluster, configMapCopy); err != nil {
 				return err
@@ -1942,7 +1955,7 @@ func (r *Reconciler) reconcilePGBackRestSecret(ctx context.Context,
 	intent.Labels = naming.Merge(
 		cluster.Spec.Metadata.GetLabelsOrNil(),
 		cluster.Spec.Backups.PGBackRest.Metadata.GetLabelsOrNil(),
-		naming.WithPerconaLabels(naming.PGBackRestConfigLabels(cluster.Name), cluster.Name, ""),
+		naming.WithPerconaLabels(naming.PGBackRestConfigLabels(cluster.Name), cluster.Name, "", cluster.Labels[naming.LabelVersion]),
 	)
 
 	existing := &corev1.Secret{}
@@ -2287,8 +2300,9 @@ func (r *Reconciler) reconcileManualBackup(ctx context.Context,
 	var labels, annotations map[string]string
 	labels = naming.Merge(postgresCluster.Spec.Metadata.GetLabelsOrNil(),
 		postgresCluster.Spec.Backups.PGBackRest.Metadata.GetLabelsOrNil(),
-		naming.PGBackRestBackupJobLabels(postgresCluster.GetName(), repoName,
-			naming.BackupManual))
+		naming.WithPerconaLabels(
+			naming.PGBackRestBackupJobLabels(postgresCluster.GetName(), repoName, naming.BackupManual),
+			postgresCluster.GetName(), "", postgresCluster.Labels[naming.LabelVersion]))
 	annotations = naming.Merge(postgresCluster.Spec.Metadata.GetAnnotationsOrNil(),
 		postgresCluster.Spec.Backups.PGBackRest.Metadata.GetAnnotationsOrNil(),
 		map[string]string{
@@ -2463,8 +2477,9 @@ func (r *Reconciler) reconcileReplicaCreateBackup(ctx context.Context,
 	var labels, annotations map[string]string
 	labels = naming.Merge(postgresCluster.Spec.Metadata.GetLabelsOrNil(),
 		postgresCluster.Spec.Backups.PGBackRest.Metadata.GetLabelsOrNil(),
-		naming.PGBackRestBackupJobLabels(postgresCluster.GetName(),
-			postgresCluster.Spec.Backups.PGBackRest.Repos[0].Name, naming.BackupReplicaCreate))
+		naming.WithPerconaLabels(
+			naming.PGBackRestBackupJobLabels(postgresCluster.GetName(), postgresCluster.Spec.Backups.PGBackRest.Repos[0].Name, naming.BackupReplicaCreate),
+			postgresCluster.GetName(), "", postgresCluster.Labels[naming.LabelVersion]))
 	annotations = naming.Merge(postgresCluster.Spec.Metadata.GetAnnotationsOrNil(),
 		postgresCluster.Spec.Backups.PGBackRest.Metadata.GetAnnotationsOrNil(),
 		map[string]string{
@@ -2862,7 +2877,8 @@ func (r *Reconciler) reconcilePGBackRestCronJob(
 	labels := naming.Merge(
 		cluster.Spec.Metadata.GetLabelsOrNil(),
 		cluster.Spec.Backups.PGBackRest.Metadata.GetLabelsOrNil(),
-		naming.PGBackRestCronJobLabels(cluster.Name, repo.Name, backupType),
+		naming.WithPerconaLabels(naming.PGBackRestCronJobLabels(cluster.Name, repo.Name, backupType),
+			cluster.Name, "", cluster.Labels[naming.LabelVersion]),
 	)
 	objectmeta := naming.PGBackRestCronJob(cluster, backupType, repo.Name)
 

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -818,11 +818,7 @@ func TestGetPGBackRestExecSelector(t *testing.T) {
 			Name:   "repo1",
 			Volume: &v1beta1.RepoPVC{},
 		},
-		expectedSelector: "app.kubernetes.io/instance=hippo," +
-			"app.kubernetes.io/managed-by=percona-postgresql-operator," +
-			"app.kubernetes.io/name=percona-postgresql," +
-			"app.kubernetes.io/part-of=percona-postgresql," +
-			"postgres-operator.crunchydata.com/cluster=hippo," +
+		expectedSelector: "postgres-operator.crunchydata.com/cluster=hippo," +
 			"postgres-operator.crunchydata.com/pgbackrest=," +
 			"postgres-operator.crunchydata.com/pgbackrest-dedicated=",
 		expectedContainer: "pgbackrest",
@@ -967,11 +963,7 @@ func TestReconcileReplicaCreateBackup(t *testing.T) {
 		case "NAMESPACE":
 			assert.Assert(t, env.Value == ns.Name)
 		case "SELECTOR":
-			assert.Assert(t, env.Value == "app.kubernetes.io/instance=hippocluster,"+
-				"app.kubernetes.io/managed-by=percona-postgresql-operator,"+
-				"app.kubernetes.io/name=percona-postgresql,"+
-				"app.kubernetes.io/part-of=percona-postgresql,"+
-				"postgres-operator.crunchydata.com/cluster=hippocluster,"+
+			assert.Assert(t, env.Value == "postgres-operator.crunchydata.com/cluster=hippocluster,"+
 				"postgres-operator.crunchydata.com/pgbackrest=,"+
 				"postgres-operator.crunchydata.com/pgbackrest-dedicated=")
 		}

--- a/internal/controller/postgrescluster/pgbouncer.go
+++ b/internal/controller/postgrescluster/pgbouncer.go
@@ -100,7 +100,7 @@ func (r *Reconciler) reconcilePGBouncerConfigMap(
 		naming.WithPerconaLabels(map[string]string{
 			naming.LabelCluster: cluster.Name,
 			naming.LabelRole:    naming.RolePGBouncer,
-		}, cluster.Name, "pgbouncer"))
+		}, cluster.Name, "pgbouncer", cluster.Labels[naming.LabelVersion]))
 
 	if err == nil {
 		pgbouncer.ConfigMap(cluster, configmap)
@@ -246,7 +246,7 @@ func (r *Reconciler) reconcilePGBouncerSecret(
 		naming.WithPerconaLabels(map[string]string{
 			naming.LabelCluster: cluster.Name,
 			naming.LabelRole:    naming.RolePGBouncer,
-		}, cluster.Name, "pgbouncer"))
+		}, cluster.Name, "pgbouncer", cluster.Labels[naming.LabelVersion]))
 
 	if err == nil {
 		err = pgbouncer.Secret(ctx, cluster, root, existing, service, intent)
@@ -289,7 +289,7 @@ func (r *Reconciler) generatePGBouncerService(
 		naming.WithPerconaLabels(map[string]string{
 			naming.LabelCluster: cluster.Name,
 			naming.LabelRole:    naming.RolePGBouncer,
-		}, cluster.Name, "pgbouncer"))
+		}, cluster.Name, "pgbouncer", cluster.Labels[naming.LabelVersion]))
 
 	// Allocate an IP address and/or node port and let Kubernetes manage the
 	// Endpoints by selecting Pods with the PgBouncer role.
@@ -384,7 +384,7 @@ func (r *Reconciler) generatePGBouncerDeployment(
 		naming.WithPerconaLabels(map[string]string{
 			naming.LabelCluster: cluster.Name,
 			naming.LabelRole:    naming.RolePGBouncer,
-		}, cluster.Name, "pgbouncer"))
+		}, cluster.Name, "pgbouncer", cluster.Labels[naming.LabelVersion]))
 	deploy.Spec.Selector = &metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			naming.LabelCluster: cluster.Name,
@@ -400,7 +400,7 @@ func (r *Reconciler) generatePGBouncerDeployment(
 		naming.WithPerconaLabels(map[string]string{
 			naming.LabelCluster: cluster.Name,
 			naming.LabelRole:    naming.RolePGBouncer,
-		}, cluster.Name, "pgbouncer"))
+		}, cluster.Name, "pgbouncer", cluster.Labels[naming.LabelVersion]))
 
 	// if the shutdown flag is set, set pgBouncer replicas to 0
 	if cluster.Spec.Shutdown != nil && *cluster.Spec.Shutdown {

--- a/internal/controller/postgrescluster/pgbouncer_test.go
+++ b/internal/controller/postgrescluster/pgbouncer_test.go
@@ -394,7 +394,6 @@ func TestGeneratePGBouncerDeployment(t *testing.T) {
 	cluster := &v1beta1.PostgresCluster{}
 	cluster.Namespace = "ns3"
 	cluster.Name = "test-cluster"
-	
 	cluster.Labels = map[string]string{
 		naming.LabelVersion: "2.3.0",
 	}

--- a/internal/controller/postgrescluster/pgbouncer_test.go
+++ b/internal/controller/postgrescluster/pgbouncer_test.go
@@ -51,6 +51,10 @@ func TestGeneratePGBouncerService(t *testing.T) {
 	cluster.Namespace = "ns5"
 	cluster.Name = "pg7"
 
+	cluster.Labels = map[string]string{
+		naming.LabelVersion: "2.3.0",
+	}
+
 	t.Run("Unspecified", func(t *testing.T) {
 		for _, spec := range []*v1beta1.PostgresProxySpec{
 			nil, new(v1beta1.PostgresProxySpec),
@@ -390,6 +394,10 @@ func TestGeneratePGBouncerDeployment(t *testing.T) {
 	cluster := &v1beta1.PostgresCluster{}
 	cluster.Namespace = "ns3"
 	cluster.Name = "test-cluster"
+	
+	cluster.Labels = map[string]string{
+		naming.LabelVersion: "2.3.0",
+	}
 
 	t.Run("Unspecified", func(t *testing.T) {
 		for _, spec := range []*v1beta1.PostgresProxySpec{

--- a/internal/controller/postgrescluster/pgbouncer_test.go
+++ b/internal/controller/postgrescluster/pgbouncer_test.go
@@ -131,7 +131,7 @@ ownerReferences:
 			"b": "v2",
 			"postgres-operator.crunchydata.com/cluster": "pg7",
 			"postgres-operator.crunchydata.com/role":    "pgbouncer",
-		}, "pg7", "pgbouncer")))
+		}, "pg7", "pgbouncer", "2.3.0")))
 
 		// Labels not in the selector.
 		assert.DeepEqual(t, service.Spec.Selector, map[string]string{
@@ -164,7 +164,7 @@ ownerReferences:
 			"d": "v4",
 			"postgres-operator.crunchydata.com/cluster": "pg7",
 			"postgres-operator.crunchydata.com/role":    "pgbouncer",
-		}, "pg7", "pgbouncer")))
+		}, "pg7", "pgbouncer", "2.3.0")))
 
 		// Labels not in the selector.
 		assert.DeepEqual(t, service.Spec.Selector, map[string]string{
@@ -445,7 +445,7 @@ namespace: ns3
 			"b": "v2",
 			"postgres-operator.crunchydata.com/cluster": "test-cluster",
 			"postgres-operator.crunchydata.com/role":    "pgbouncer",
-		}, "test-cluster", "pgbouncer")))
+		}, "test-cluster", "pgbouncer", "2.3.0")))
 
 		// Labels not in the pod selector.
 		assert.DeepEqual(t, deploy.Spec.Selector,
@@ -466,7 +466,7 @@ namespace: ns3
 			"b": "v2",
 			"postgres-operator.crunchydata.com/cluster": "test-cluster",
 			"postgres-operator.crunchydata.com/role":    "pgbouncer",
-		}, "test-cluster", "pgbouncer")))
+		}, "test-cluster", "pgbouncer", "2.3.0")))
 	})
 
 	t.Run("PodSpec", func(t *testing.T) {

--- a/internal/controller/postgrescluster/pki.go
+++ b/internal/controller/postgrescluster/pki.go
@@ -159,7 +159,7 @@ func (r *Reconciler) reconcileClusterCertificate(
 		naming.WithPerconaLabels(map[string]string{
 			naming.LabelCluster:            cluster.Name,
 			naming.LabelClusterCertificate: "postgres-tls",
-		}, cluster.Name, ""))
+		}, cluster.Name, "", cluster.Labels[naming.LabelVersion]))
 
 	// K8SPG-330: Keep this commented in case of conflicts.
 	// We don't want to delete TLS secrets on cluster deletion.

--- a/internal/controller/postgrescluster/postgres.go
+++ b/internal/controller/postgrescluster/postgres.go
@@ -180,7 +180,7 @@ func (r *Reconciler) generatePostgresUserSecret(
 			naming.LabelCluster:      cluster.Name,
 			naming.LabelRole:         naming.RolePostgresUser,
 			naming.LabelPostgresUser: username,
-		}, cluster.Name, ""))
+		}, cluster.Name, "", cluster.Labels[naming.LabelVersion]))
 
 	// K8SPG-328: Keep this commented in case of conflicts.
 	// We don't want to delete secrets if custom resource is deleted.
@@ -583,7 +583,7 @@ func (r *Reconciler) reconcilePostgresDataVolume(
 	pvc.Labels = naming.Merge(
 		cluster.Spec.Metadata.GetLabelsOrNil(),
 		instanceSpec.Metadata.GetLabelsOrNil(),
-		naming.WithPerconaLabels(labelMap, cluster.Name, ""),
+		naming.WithPerconaLabels(labelMap, cluster.Name, "", cluster.Labels[naming.LabelVersion]),
 	)
 
 	pvc.Spec = instanceSpec.DataVolumeClaimSpec
@@ -650,7 +650,7 @@ func (r *Reconciler) reconcileTablespaceVolumes(
 		pvc.Labels = naming.Merge(
 			cluster.Spec.Metadata.GetLabelsOrNil(),
 			instanceSpec.Metadata.GetLabelsOrNil(),
-			naming.WithPerconaLabels(labelMap, cluster.Name, ""),
+			naming.WithPerconaLabels(labelMap, cluster.Name, "", cluster.Labels[naming.LabelVersion]),
 		)
 
 		pvc.Spec = vol.DataVolumeClaimSpec
@@ -762,7 +762,7 @@ func (r *Reconciler) reconcilePostgresWALVolume(
 	pvc.Labels = naming.Merge(
 		cluster.Spec.Metadata.GetLabelsOrNil(),
 		instanceSpec.Metadata.GetLabelsOrNil(),
-		naming.WithPerconaLabels(labelMap, cluster.Name, ""),
+		naming.WithPerconaLabels(labelMap, cluster.Name, "", cluster.Labels[naming.LabelVersion]),
 	)
 
 	pvc.Spec = *instanceSpec.WALVolumeClaimSpec

--- a/internal/controller/postgrescluster/postgres_test.go
+++ b/internal/controller/postgrescluster/postgres_test.go
@@ -67,7 +67,7 @@ func TestGeneratePostgresUserSecret(t *testing.T) {
 				"postgres-operator.crunchydata.com/cluster": "hippo2",
 				"postgres-operator.crunchydata.com/role":    "pguser",
 				"postgres-operator.crunchydata.com/pguser":  "some-user-name",
-			}, cluster.Name, "")))
+			}, cluster.Name, "", "2.3.0")))
 		}
 	})
 

--- a/internal/controller/postgrescluster/postgres_test.go
+++ b/internal/controller/postgrescluster/postgres_test.go
@@ -52,6 +52,10 @@ func TestGeneratePostgresUserSecret(t *testing.T) {
 	cluster.Name = "hippo2"
 	cluster.Spec.Port = initialize.Int32(9999)
 
+	cluster.Labels = map[string]string{
+		naming.LabelVersion: "2.3.0",
+	}
+
 	spec := &v1beta1.PostgresUserSpec{Name: "some-user-name"}
 
 	t.Run("ObjectMeta", func(t *testing.T) {

--- a/internal/controller/postgrescluster/volumes.go
+++ b/internal/controller/postgrescluster/volumes.go
@@ -228,7 +228,7 @@ func (r *Reconciler) configureExistingPGVolumes(
 				naming.LabelInstance:    instanceName,
 				naming.LabelRole:        naming.RolePostgresData,
 				naming.LabelData:        naming.DataPostgres,
-			}, cluster.Name, "")
+			}, cluster.Name, "", cluster.Labels[naming.LabelVersion])
 			volume.SetGroupVersionKind(corev1.SchemeGroupVersion.
 				WithKind("PersistentVolumeClaim"))
 			// K8SPG-328: Keep this commented in case of conflicts.
@@ -283,7 +283,7 @@ func (r *Reconciler) configureExistingPGWALVolume(
 			naming.LabelInstance:    instanceName,
 			naming.LabelRole:        naming.RolePostgresWAL,
 			naming.LabelData:        naming.DataPostgres,
-		}, cluster.Name, "")
+		}, cluster.Name, "", cluster.Labels[naming.LabelVersion])
 		volume.SetGroupVersionKind(corev1.SchemeGroupVersion.
 			WithKind("PersistentVolumeClaim"))
 		// K8SPG-328: Keep this commented in case of conflicts.
@@ -327,8 +327,9 @@ func (r *Reconciler) configureExistingRepoVolumes(
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      volName,
 					Namespace: cluster.Namespace,
-					Labels: naming.PGBackRestRepoVolumeLabels(cluster.Name,
-						cluster.Spec.Backups.PGBackRest.Repos[0].Name),
+					Labels: naming.WithPerconaLabels(
+						naming.PGBackRestRepoVolumeLabels(cluster.Name, cluster.Spec.Backups.PGBackRest.Repos[0].Name),
+						cluster.Name, "", cluster.Labels[naming.LabelVersion]),
 				},
 				Spec: cluster.Spec.Backups.PGBackRest.Repos[0].Volume.
 					VolumeClaimSpec,

--- a/internal/controller/postgrescluster/volumes_test.go
+++ b/internal/controller/postgrescluster/volumes_test.go
@@ -499,7 +499,7 @@ func TestReconcileConfigureExistingPVCs(t *testing.T) {
 			naming.LabelRole:        naming.RolePostgresData,
 			naming.LabelData:        naming.DataPostgres,
 			"somelabel":             "labelvalue-pgdata",
-		}, cluster.Name, ""))
+		}, cluster.Name, "", "2.3.0"))
 
 		// ensure volume is found and labeled correctly
 		var found bool
@@ -565,7 +565,7 @@ func TestReconcileConfigureExistingPVCs(t *testing.T) {
 			naming.LabelRole:        naming.RolePostgresWAL,
 			naming.LabelData:        naming.DataPostgres,
 			"somelabel":             "labelvalue-pgwal",
-		}, cluster.Name, ""))
+		}, cluster.Name, "", "2.3.0"))
 
 		// ensure volume is found and labeled correctly
 		var found bool
@@ -633,7 +633,7 @@ func TestReconcileConfigureExistingPVCs(t *testing.T) {
 			naming.LabelPGBackRestRepo:       "repo1",
 			naming.LabelPGBackRestRepoVolume: "",
 			"somelabel":                      "labelvalue-repo",
-		}, cluster.Name, ""))
+		}, cluster.Name, "", "2.3.0"))
 
 		// ensure volume is found and labeled correctly
 		var found bool

--- a/internal/controller/postgrescluster/volumes_test.go
+++ b/internal/controller/postgrescluster/volumes_test.go
@@ -400,6 +400,9 @@ func TestReconcileConfigureExistingPVCs(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testcluster",
 			Namespace: ns.GetName(),
+			Labels: map[string]string{
+				naming.LabelVersion: "2.3.0",
+			},
 		},
 		Spec: v1beta1.PostgresClusterSpec{
 			PostgresVersion: 13,

--- a/internal/naming/labels_test.go
+++ b/internal/naming/labels_test.go
@@ -149,7 +149,7 @@ func TestPGBackRestLabelFuncs(t *testing.T) {
 	repoName := "hippo-repo"
 
 	// verify the labels that identify pgBackRest resources
-	pgBackRestLabels := WithPerconaLabels(PGBackRestLabels(clusterName), clusterName, "")
+	pgBackRestLabels := WithPerconaLabels(PGBackRestLabels(clusterName), clusterName, "", "2.3.0")
 	assert.Equal(t, pgBackRestLabels.Get(LabelCluster), clusterName)
 	assert.Check(t, pgBackRestLabels.Has(LabelPGBackRest))
 

--- a/internal/naming/labels_test.go
+++ b/internal/naming/labels_test.go
@@ -149,7 +149,7 @@ func TestPGBackRestLabelFuncs(t *testing.T) {
 	repoName := "hippo-repo"
 
 	// verify the labels that identify pgBackRest resources
-	pgBackRestLabels := WithPerconaLabels(PGBackRestLabels(clusterName), clusterName, "", "2.3.0")
+	pgBackRestLabels := PGBackRestLabels(clusterName)
 	assert.Equal(t, pgBackRestLabels.Get(LabelCluster), clusterName)
 	assert.Check(t, pgBackRestLabels.Has(LabelPGBackRest))
 

--- a/internal/pgbackrest/config.go
+++ b/internal/pgbackrest/config.go
@@ -86,7 +86,8 @@ func CreatePGBackRestConfigMapIntent(postgresCluster *v1beta1.PostgresCluster,
 	meta.Labels = naming.Merge(
 		postgresCluster.Spec.Metadata.GetLabelsOrNil(),
 		postgresCluster.Spec.Backups.PGBackRest.Metadata.GetLabelsOrNil(),
-		naming.PGBackRestConfigLabels(postgresCluster.GetName()),
+		naming.WithPerconaLabels(naming.PGBackRestConfigLabels(postgresCluster.GetName()),
+			postgresCluster.GetName(), "", postgresCluster.Labels[naming.LabelVersion]),
 	)
 
 	cm := &corev1.ConfigMap{

--- a/internal/pgbackrest/config_test.go
+++ b/internal/pgbackrest/config_test.go
@@ -43,6 +43,10 @@ func TestCreatePGBackRestConfigMapIntent(t *testing.T) {
 	cluster.Spec.Port = initialize.Int32(2345)
 	cluster.Spec.PostgresVersion = 12
 
+	cluster.Labels = map[string]string{
+		naming.LabelVersion: "2.3.0",
+	}
+
 	domain := naming.KubernetesClusterDomain(context.Background())
 
 	t.Run("NoVolumeRepo", func(t *testing.T) {

--- a/internal/pgbackrest/config_test.go
+++ b/internal/pgbackrest/config_test.go
@@ -92,7 +92,7 @@ func TestCreatePGBackRestConfigMapIntent(t *testing.T) {
 			"postgres-operator.crunchydata.com/cluster":           "hippo-dance",
 			"postgres-operator.crunchydata.com/pgbackrest":        "",
 			"postgres-operator.crunchydata.com/pgbackrest-config": "",
-		}, "hippo-dance", "")))
+		}, "hippo-dance", "", "2.3.0")))
 
 		assert.Equal(t, configmap.Data["config-hash"], "abcde12345")
 		assert.Equal(t, configmap.Data["pgbackrest_repo.conf"], strings.Trim(`
@@ -202,7 +202,7 @@ pg1-socket-path = /tmp/postgres
 			"postgres-operator.crunchydata.com/cluster":           "hippo-dance",
 			"postgres-operator.crunchydata.com/pgbackrest":        "",
 			"postgres-operator.crunchydata.com/pgbackrest-config": "",
-		}, "hippo-dance", "")))
+		}, "hippo-dance", "", "2.3.0")))
 	})
 }
 

--- a/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
+++ b/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
@@ -238,6 +238,10 @@ func (cr *PerconaPGCluster) ToCrunchy(ctx context.Context, postgresCluster *crun
 	}
 	postgresCluster.Annotations = annotations
 	postgresCluster.Labels = cr.Labels
+	if postgresCluster.Labels == nil {
+		postgresCluster.Labels = make(map[string]string)
+	}
+	postgresCluster.Labels[LabelOperatorVersion] = cr.Spec.CRVersion
 
 	postgresCluster.Spec.Image = cr.Spec.Image
 	postgresCluster.Spec.ImagePullPolicy = cr.Spec.ImagePullPolicy


### PR DESCRIPTION
[![K8SPG-430](https://badgen.net/badge/JIRA/K8SPG-430/green)](https://jira.percona.com/browse/K8SPG-430) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
New labels were added on older versions of the operator which should not be the case.

**Solution:**
Add labels only to 2.3.0 and above.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PG version?
- [x] Does the change support oldest and newest supported Kubernetes version?