### PR TITLE
K8SPG-467 - Fix job diff for newer k8s

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -730,7 +730,7 @@ compare_kubectl() {
 		| yq d - 'metadata.annotations."cloud.google.com/neg"' \
 		| yq d - 'metadata.annotations."batch.kubernetes.io/job-tracking"' \
 		| yq d - '**."batch.kubernetes.io/controller-uid"' \
-		| yq d - '**."batch.kubernetes.io/job-name"' \
+		| yq d - 'spec.template.metadata.labels."batch.kubernetes.io/job-name"' \
 		| yq d - '**.creationTimestamp' \
 		| yq d - '**.image' \
 		| yq d - '**.clusterIP' \

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -729,6 +729,8 @@ compare_kubectl() {
 		| yq d - 'metadata.annotations."kubernetes.io/psp"' \
 		| yq d - 'metadata.annotations."cloud.google.com/neg"' \
 		| yq d - 'metadata.annotations."batch.kubernetes.io/job-tracking"' \
+		| yq d - '**."batch.kubernetes.io/controller-uid"' \
+		| yq d - '**."batch.kubernetes.io/job-name"' \
 		| yq d - '**.creationTimestamp' \
 		| yq d - '**.image' \
 		| yq d - '**.clusterIP' \


### PR DESCRIPTION
[![K8SPG-467](https://badgen.net/badge/JIRA/K8SPG-467/green)](https://jira.percona.com/browse/K8SPG-467) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
```
+ diff -u /Users/plavi/Development/percona/kubernetes/percona/percona-postgresql-operator-v1/e2e-tests/affinity/compare/job_backrest-backup-some-name.yml /var/folders/fw/lxhtthdn7d9610w5p3wb33340000gn/T/tmp.XZOwxeWSUi/job_backrest-backup-some-name.yml
--- /Users/plavi/Development/percona/kubernetes/percona/percona-postgresql-operator-v1/e2e-tests/affinity/compare/job_backrest-backup-some-name.yml 2023-11-21 09:04:44
+++ /var/folders/fw/lxhtthdn7d9610w5p3wb33340000gn/T/tmp.XZOwxeWSUi/job_backrest-backup-some-name.yml   2023-11-21 11:37:30
@@ -15,11 +15,14 @@
   completions: 1
   parallelism: 1
   selector:
-    matchLabels: {}
+    matchLabels:
+      batch.kubernetes.io/controller-uid: 7f2b7b64-bb04-4be5-b0d2-130c2f6388e0
   template:
     metadata:
       labels:
         backrest-command: backup
+        batch.kubernetes.io/controller-uid: 7f2b7b64-bb04-4be5-b0d2-130c2f6388e0
+        batch.kubernetes.io/job-name: backrest-backup-some-name
         job-name: backrest-backup-some-name
         pg-cluster: some-name
         pgo-backrest: "true"
```

**Solution:**
*Filter out these fields from comparison.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?