### PR TITLE
K8SPG-464: Fix unscheduled backups if anti affinity is required

### DIFF
--- a/e2e-tests/affinity/compare/job_backrest-backup-some-name-required.yml
+++ b/e2e-tests/affinity/compare/job_backrest-backup-some-name-required.yml
@@ -45,7 +45,7 @@ spec:
                     operator: In
                     values:
                       - some-name-required
-                  - key: pgo-pg-database
+                  - key: pgo-backrest-job
                     operator: Exists
               topologyKey: kubernetes.io/hostname
       containers:

--- a/e2e-tests/affinity/compare/job_backrest-backup-some-name.yml
+++ b/e2e-tests/affinity/compare/job_backrest-backup-some-name.yml
@@ -43,7 +43,7 @@ spec:
                       operator: In
                       values:
                         - some-name
-                    - key: pgo-pg-database
+                    - key: pgo-backrest-job
                       operator: Exists
                 topologyKey: kubernetes.io/hostname
               weight: 1

--- a/e2e-tests/affinity/run
+++ b/e2e-tests/affinity/run
@@ -16,6 +16,8 @@ compare_kubectl "deployment/${cluster}"
 compare_kubectl "deployment/${cluster}-backrest-shared-repo"
 compare_kubectl "job/backrest-backup-${cluster}"
 
+create_backup ${cluster} "preferred"
+
 kubectl_bin delete perconapgcluster ${cluster}
 sleep 30
 
@@ -26,6 +28,8 @@ compare_kubectl "deployment/${cluster}"
 compare_kubectl "deployment/${cluster}-backrest-shared-repo"
 compare_kubectl "job/backrest-backup-${cluster}"
 
+create_backup ${cluster} "required"
+
 kubectl_bin delete perconapgcluster ${cluster}
 sleep 30
 
@@ -35,5 +39,7 @@ spinup_pgcluster "${cluster}" "${src_dir}/deploy/cr.yaml" '' '' "disabled"
 compare_kubectl "deployment/${cluster}"
 compare_kubectl "deployment/${cluster}-backrest-shared-repo"
 compare_kubectl "job/backrest-backup-${cluster}"
+
+create_backup ${cluster} "disabled"
 
 destroy ${namespace}

--- a/installers/ansible/roles/pgo-operator/files/pgo-configs/pod-anti-affinity.json
+++ b/installers/ansible/roles/pgo-operator/files/pgo-configs/pod-anti-affinity.json
@@ -48,6 +48,11 @@
                                             "key": "crunchy-pgbouncer",
                                             "operator": "Exists"
                                         }
+                                        {{ else if eq .DeploymentType "3" }}
+                                        {
+                                            "key": "pgo-backrest-job",
+                                            "operator": "Exists"
+                                        }
                                         {{ end }}
                                     ]
                                 },

--- a/internal/operator/backrest/backup.go
+++ b/internal/operator/backrest/backup.go
@@ -123,7 +123,7 @@ func Backrest(namespace string, clientset kubeapi.Interface, task *crv1.Pgtask) 
 
 	var customAffinity string
 	nodeSelector := operator.GetNodeAffinity(cluster.Spec.NodeAffinity.Default)
-	podAntiAffinity := operator.GetPodAntiAffinity(cluster, crv1.PodAntiAffinityDeploymentDefault, cluster.Spec.PodAntiAffinity.Default)
+	podAntiAffinity := operator.GetPodAntiAffinity(cluster, crv1.PodAntiAffinityDeploymentPgBackRestJob, cluster.Spec.PodAntiAffinity.Default)
 	podAntiAffinityLabelValue := string(cluster.Spec.PodAntiAffinity.Default)
 
 	affinityJSON, ok := task.Spec.Parameters[config.LABEL_AFFINITY_JSON]
@@ -146,7 +146,7 @@ func Backrest(namespace string, clientset kubeapi.Interface, task *crv1.Pgtask) 
 			}
 
 			nodeSelector = operator.GetNodeAffinity(nodeAffinity)
-			podAntiAffinity = operator.GetPodAntiAffinity(cluster, crv1.PodAntiAffinityDeploymentDefault, affinity.AntiAffinityType)
+			podAntiAffinity = operator.GetPodAntiAffinity(cluster, crv1.PodAntiAffinityDeploymentPgBackRestJob, affinity.AntiAffinityType)
 			podAntiAffinityLabelValue = string(affinity.AntiAffinityType)
 
 			if affinity.Advanced != nil {

--- a/pkg/apis/crunchydata.com/v1/cluster.go
+++ b/pkg/apis/crunchydata.com/v1/cluster.go
@@ -307,11 +307,12 @@ type PodAntiAffinityType string
 
 // PodAntiAffinitySpec provides multiple configurations for how pod
 // anti-affinity can be set.
-// - "Default" is the default rule that applies to all Pods that are a part of
-//		the PostgreSQL cluster
-// - "PgBackrest" applies just to the pgBackRest repository Pods in said
-//		Deployment
-// - "PgBouncer" applies to just pgBouncer Pods in said Deployment
+//   - "Default" is the default rule that applies to all Pods that are a part of
+//     the PostgreSQL cluster
+//   - "PgBackrest" applies just to the pgBackRest repository Pods in said
+//     Deployment
+//   - "PgBouncer" applies to just pgBouncer Pods in said Deployment
+//
 // swaggier:ignore
 type PodAntiAffinitySpec struct {
 	Default    PodAntiAffinityType `json:"default"`
@@ -419,6 +420,7 @@ const (
 	PodAntiAffinityDeploymentDefault PodAntiAffinityDeployment = iota
 	PodAntiAffinityDeploymentPgBackRest
 	PodAntiAffinityDeploymentPgBouncer
+	PodAntiAffinityDeploymentPgBackRestJob
 )
 
 // ValidatePodAntiAffinityType is responsible for validating whether or not the type of pod


### PR DESCRIPTION
[![K8SPG-464](https://badgen.net/badge/JIRA/K8SPG-464/green)](https://jira.percona.com/browse/K8SPG-464) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Backups are stuck because of anti affinity configuration.

**Cause:**
Backup pods configures anti affinity with postgres labels rather than pgbackrest labels.

**Solution:**
Configure backup job anti affinity with correct labels.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PG version?
- [x] Does the change support oldest and newest supported Kubernetes version?