### PR TITLE
K8SPG-472: Fix re-enabling built-in extensions after disabling

### DIFF
--- a/internal/controller/postgrescluster/postgres.go
+++ b/internal/controller/postgrescluster/postgres.go
@@ -251,8 +251,7 @@ func (r *Reconciler) reconcilePostgresDatabases(
 					"Unable to install pgStatMonitor")
 			}
 		} else {
-			err := pgstatmonitor.DisableInPostgreSQL(ctx, exec)
-			if err != nil {
+			if pgStatMonitorOK = pgstatmonitor.DisableInPostgreSQL(ctx, exec) == nil; !pgStatMonitorOK {
 				r.Recorder.Event(cluster, corev1.EventTypeWarning, "pgStatMonitorEnabled",
 					"Unable to disable pgStatMonitor")
 			}
@@ -268,8 +267,7 @@ func (r *Reconciler) reconcilePostgresDatabases(
 					"Unable to install pgAudit")
 			}
 		} else {
-			err := pgaudit.DisableInPostgreSQL(ctx, exec)
-			if err != nil {
+			if pgAuditOK = pgaudit.DisableInPostgreSQL(ctx, exec) == nil; !pgAuditOK {
 				r.Recorder.Event(cluster, corev1.EventTypeWarning, "pgAuditEnabled",
 					"Unable to disable pgAudit")
 			}
@@ -318,7 +316,8 @@ func (r *Reconciler) reconcilePostgresDatabases(
 		log := logging.FromContext(ctx).WithValues("revision", revision)
 		err = errors.WithStack(create(logging.NewContext(ctx, log), podExecutor))
 	}
-	if err == nil && pgAuditOK && postgisInstallOK {
+
+	if err == nil && pgStatMonitorOK && pgAuditOK && postgisInstallOK {
 		cluster.Status.DatabaseRevision = revision
 	}
 


### PR DESCRIPTION
[![K8SPG-472](https://badgen.net/badge/JIRA/K8SPG-472/green)](https://jira.percona.com/browse/K8SPG-472) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Built-in extensions can't be enabled after disabling.

**Cause:**
Bug in database revision calculation prevents re-enabling.

**Solution:**
Squash the bug.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PG version?
- [x] Does the change support oldest and newest supported Kubernetes version?