### PR TITLE
K8SPG-486 The IMAGE_EXT_INSTALLER variable was using wrong image

### DIFF
--- a/e2e-tests/vars.sh
+++ b/e2e-tests/vars.sh
@@ -22,7 +22,6 @@ export IMAGE_PMM_CLIENT=${IMAGE_PMM_CLIENT:-"perconalab/pmm-client:dev-latest"}
 export IMAGE_PMM_SERVER=${IMAGE_PMM_SERVER:-"perconalab/pmm-server:dev-latest"}
 export PGOV1_TAG=${PGOV1_TAG:-"1.4.0"}
 export PGOV1_VER=${PGOV1_VER:-"14"}
-export IMAGE_EXT_INSTALLER=${IMAGE_EXT_INSTALLER:-"perconalab/percona-postgresql-operator"}
 
 date=$(which gdate || which date)
 sed=$(which gsed || which sed)

--- a/e2e-tests/vars.sh
+++ b/e2e-tests/vars.sh
@@ -22,7 +22,7 @@ export IMAGE_PMM_CLIENT=${IMAGE_PMM_CLIENT:-"perconalab/pmm-client:dev-latest"}
 export IMAGE_PMM_SERVER=${IMAGE_PMM_SERVER:-"perconalab/pmm-server:dev-latest"}
 export PGOV1_TAG=${PGOV1_TAG:-"1.4.0"}
 export PGOV1_VER=${PGOV1_VER:-"14"}
-export IMAGE_EXT_INSTALLER=${IMAGE_EXT_INSTALLER:-"perconalab/percona-postgresql-operator:main-ext-installer"}
+export IMAGE_EXT_INSTALLER=${IMAGE_EXT_INSTALLER:-"perconalab/percona-postgresql-operator"}
 
 date=$(which gdate || which date)
 sed=$(which gsed || which sed)


### PR DESCRIPTION
[![K8SPG-486](https://badgen.net/badge/JIRA/K8SPG-486/green)](https://jira.percona.com/browse/K8SPG-486) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?