### PR TITLE
K8SPG-358 Update timeout value in 08-assert.yaml of scheduled-backup test case

### DIFF
--- a/e2e-tests/tests/migration-backup-s3/05-run-v1-s3-backup.yaml
+++ b/e2e-tests/tests/migration-backup-s3/05-run-v1-s3-backup.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 300
 commands:
   - script: |-
       set -o errexit
@@ -27,3 +26,4 @@ commands:
       sleep 5
       kubectl -n $NAMESPACE wait --for=condition=Complete job/data-$POSTGRES_V1_CLUSTER_NAME --timeout=300s
       exit
+    timeout: 300

--- a/e2e-tests/tests/scheduled-backup/08-assert.yaml
+++ b/e2e-tests/tests/scheduled-backup/08-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 180
+timeout: 220
 ---
 apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster


### PR DESCRIPTION
[![K8SPG-358](https://badgen.net/badge/JIRA/K8SPG-358/green)](https://jira.percona.com/browse/K8SPG-358) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-358]: https://perconadev.atlassian.net/browse/K8SPG-358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ