### PR TITLE
K8SPG-358 - Fix scheduled-backup test for OpenShift and EKS

### DIFF
--- a/e2e-tests/tests/scheduled-backup/07-add-more-data.yaml
+++ b/e2e-tests/tests/scheduled-backup/07-add-more-data.yaml
@@ -20,3 +20,4 @@ commands:
       data=$(run_psql_local '\c myapp \\\ SELECT * from myApp;' "postgres:$(get_psql_user_pass scheduled-backup-pguser-postgres)@$(get_psql_user_host scheduled-backup-pguser-postgres)")
 
       kubectl create configmap -n "${NAMESPACE}" 07-add-more-data --from-literal=data="${data}"
+      sleep 30 # wait for wal to get archived

--- a/e2e-tests/tests/scheduled-backup/08-assert.yaml
+++ b/e2e-tests/tests/scheduled-backup/08-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 220
+timeout: 180
 ---
 apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster

--- a/e2e-tests/tests/scheduled-backup/10-add-more-data.yaml
+++ b/e2e-tests/tests/scheduled-backup/10-add-more-data.yaml
@@ -14,3 +14,4 @@ commands:
       data=$(run_psql_local '\c myapp \\\ SELECT * from myApp;' "postgres:$(get_psql_user_pass scheduled-backup-pguser-postgres)@$(get_psql_user_host scheduled-backup-pguser-postgres)")
 
       kubectl create configmap -n "${NAMESPACE}" 10-add-more-data --from-literal=data="${data}"
+      sleep 30 # wait for wal to get archived


### PR DESCRIPTION
[![K8SPG-358](https://badgen.net/badge/JIRA/K8SPG-358/green)](https://jira.percona.com/browse/K8SPG-358) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
*scheduled-backup test was failing sporadically because WAL was not archived each time.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-358]: https://perconadev.atlassian.net/browse/K8SPG-358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ