### PR TITLE
CLOUD-820 README update to mention documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,37 +23,49 @@ Whether you need to get a simple PostgreSQL cluster up and running, need to depl
 - Scheduled and manual backups
 - Integrated monitoring with [Percona Monitoring and Management](https://www.percona.com/software/database-tools/percona-monitoring-and-management)
 
-# Architecture
+You interact with Percona Operator mostly via the command line tool. If you feel more comfortable with operating the Operator and database clusters via the web interface, there is [Percona Everest](https://docs.percona.com/everest/index.html) - an open-source web-based database provisioning tool available for you. It automates day-to-day database management operations for you, reducing the overall administrative overhead. [Get started with Percona Everest](https://docs.percona.com/everest/quickstart-guide/quick-install.html).
+
+## Architecture
 
 Percona Operators are based on the [Operator SDK](https://github.com/operator-framework/operator-sdk) and leverage Kubernetes primitives to follow best CNCF practices.
 
-Please read more about architecture and design decisions [here](https://docs.percona.com/percona-operator-for-postgresql/2.0/architecture.html).
+Learn more about [architecture and design decisions](https://docs.percona.com/percona-operator-for-postgresql/2.0/architecture.html).
+
+## Documentation
+
+To learn more about the Operator, check the [Percona Operator for PostgreSQL documentation](https://docs.percona.com/percona-operator-for-postgresql/2.0/index.html). 
 
 ## Quickstart installation
 
+Ready to try out the Operator? Check the [Quickstart tutorial](https://docs.percona.com/percona-operator-for-postgresql/2.0/quickstart.html) for easy-to follow steps. 
+
+Below is one of the ways to deploy the Operator using `kubectl`.
+
 ### kubectl
 
-Quickly making the Operator up and running with cloud native PostgreSQL includes two main steps:
-
-Deploy the operator from `deploy/bundle.yam`
+1. Deploy the operator from `deploy/bundle.yam`
 
 ```sh
 kubectl apply --server-side -f https://raw.githubusercontent.com/percona/percona-postgresql-operator/main/deploy/bundle.yaml
 ```
 
-Deploy the database cluster itself from `deploy/cr.yaml`
+2. Deploy the database cluster itself from `deploy/cr.yaml`
 
 ```sh
 kubectl apply -f https://raw.githubusercontent.com/percona/percona-postgresql-operator/main/deploy/cr.yaml
 ```
 
-# Contributing
+## Contributing
 
 Percona welcomes and encourages community contributions to help improve Percona Operator for PostgreSQL.
 
-See the [Contribution Guide](CONTRIBUTING.md) for more information.
+See the [Contribution Guide](CONTRIBUTING.md) on how you can contribute.
 
-# Join Percona Kubernetes Squad!                                                                             
+## Communication
+
+We would love to hear from you! Reach out to us on [Forum]() with your questions, feedback and ideas
+
+## Join Percona Kubernetes Squad!                                                                             
 ```                                                                                     
                     %                        _____                
                    %%%                      |  __ \                                          
@@ -73,10 +85,12 @@ See the [Contribution Guide](CONTRIBUTING.md) for more information.
 
 You can get early access to new product features, invite-only ”ask me anything” sessions with Percona Kubernetes experts, and monthly swag raffles. Interested? Fill in the form at [percona.com/k8s](https://www.percona.com/k8s).
 
-# Roadmap
+## Roadmap
 
 We have an experimental public roadmap which can be found [here](https://github.com/percona/roadmap/projects/1). Please feel free to contribute and propose new features by following the roadmap [guidelines](https://github.com/percona/roadmap).
 
-# Submitting Bug Reports
+## Submitting Bug Reports
 
-If you find a bug in Percona Docker Images or in one of the related projects, please submit a report to that project's [JIRA](https://jira.percona.com/browse/K8SPG) issue tracker. Learn more about submitting bugs, new features ideas and improvements in the [Contribution Guide](CONTRIBUTING.md).
+If you find a bug in Percona Docker Images or in one of the related projects, please submit a report to that project's [JIRA](https://jira.percona.com/browse/K8SPG) issue tracker or [create a GitHub issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue#creating-an-issue-from-a-repository) in this repository. 
+
+Learn more about submitting bugs, new features ideas and improvements in the [Contribution Guide](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ See the [Contribution Guide](CONTRIBUTING.md) on how you can contribute.
 
 ## Communication
 
-We would love to hear from you! Reach out to us on [Forum]() with your questions, feedback and ideas
+We would love to hear from you! Reach out to us on [Forum](https://forums.percona.com/c/postgresql/percona-kubernetes-operator-for-postgresql/68) with your questions, feedback and ideas
 
 ## Join Percona Kubernetes Squad!                                                                             
 ```                                                                                     


### PR DESCRIPTION
[![CLOUD-820](https://badgen.net/badge/JIRA/CLOUD-820/green)](https://jira.percona.com/browse/CLOUD-820) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

modified:   README.md

**CHANGE DESCRIPTION**
---
**Problem:** 
READMEs across all Operators are misaligned, having different structure, content and lacking links to Documentation

*Short explanation of the problem.* 
Update README to mention documentation

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
Added Docs links, updated READMe structure and content

*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[CLOUD-820]: https://perconadev.atlassian.net/browse/CLOUD-820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ