### PR TITLE
K8SPG-493: disable scheduled backups when `.spec.pause: true`

### DIFF
--- a/percona/controller/pgcluster/controller.go
+++ b/percona/controller/pgcluster/controller.go
@@ -66,6 +66,9 @@ func (r *PGClusterReconciler) SetupWithManager(mgr manager.Manager) error {
 	if err := r.CrunchyController.Watch(source.Kind(mgr.GetCache(), &batchv1.Job{}), r.watchBackupJobs()); err != nil {
 		return errors.Wrap(err, "unable to watch jobs")
 	}
+	if err := r.CrunchyController.Watch(source.Kind(mgr.GetCache(), &v2.PerconaPGBackup{}), r.watchPGBackups()); err != nil {
+		return errors.Wrap(err, "unable to watch pg-backups")
+	}
 
 	return builder.ControllerManagedBy(mgr).
 		For(&v2.PerconaPGCluster{}).

--- a/percona/controller/pgcluster/schedule.go
+++ b/percona/controller/pgcluster/schedule.go
@@ -101,6 +101,10 @@ func (r *PGClusterReconciler) createScheduledBackup(log logr.Logger, backupName,
 		}
 		return err
 	}
+	if cr.Status.State != v2.AppStateReady {
+		log.Info("Cluster is not ready. Can't start scheduled backup")
+		return nil
+	}
 
 	pb := &v2.PerconaPGBackup{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
[![K8SPG-493](https://badgen.net/badge/JIRA/K8SPG-493/green)](https://jira.percona.com/browse/K8SPG-493) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPG-493

**DESCRIPTION**
---
**Problem:**
*When `.spec.pause` is set to true in `PerconaPGCluster`, operator creates scheduled backup*

**Solution:**
*Check if the cluster is paused before trying to create the scheduled backup.*

Also, this PR reduces the chances of `pg-backup` stuck in `Starting` state, which is caused by crunchy reconcile not triggered by `pg-backup` update. This is done by adding a watch function to the crunchy controller.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-493]: https://perconadev.atlassian.net/browse/K8SPG-493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ