### PR TITLE
K8SPG-519 Extensions endpoint

### DIFF
--- a/build/crd/percona/generated/pgv2.percona.com_perconapgclusters.yaml
+++ b/build/crd/percona/generated/pgv2.percona.com_perconapgclusters.yaml
@@ -7144,6 +7144,8 @@ spec:
                     properties:
                       bucket:
                         type: string
+                      endpoint:
+                        type: string
                       region:
                         type: string
                       secret:

--- a/build/postgres-operator/install-extensions.sh
+++ b/build/postgres-operator/install-extensions.sh
@@ -5,24 +5,24 @@ set -o xtrace
 
 IFS=',' read -ra extensions <<<"$INSTALL_EXTENSIONS"
 for key in "${extensions[@]}"; do
-	if [ -f ${PGDATA_EXTENSIONS}/${key}.installed ]; then
+	if [ -f "${PGDATA_EXTENSIONS}"/"${key}".installed ]; then
 		echo "Extension ${key} already installed"
 		continue
 	fi
 
 	echo "Installing extension: ${key}"
 	/usr/local/bin/extension-installer \
-		-type ${STORAGE_TYPE} \
+		-type "${STORAGE_TYPE}" \
 		${STORAGE_ENDPOINT:+-endpoint "$STORAGE_ENDPOINT"} \
-		-region ${STORAGE_REGION} \
-		-bucket ${STORAGE_BUCKET} \
-		-extension-path ${PGDATA_EXTENSIONS} \
-		-key ${key} \
+		-region "${STORAGE_REGION}" \
+		-bucket "${STORAGE_BUCKET}" \
+		-extension-path "${PGDATA_EXTENSIONS}" \
+		-key "${key}" \
 		-install
 done
 
-for installed in ${PGDATA_EXTENSIONS}/*.installed; do
-	filename=$(basename -- ${installed})
+for installed in "${PGDATA_EXTENSIONS}"/*.installed; do
+	filename=$(basename -- "${installed}")
 	key=${filename%.*}
 	if [[ ${key} == "*" ]]; then
 		continue
@@ -31,12 +31,12 @@ for installed in ${PGDATA_EXTENSIONS}/*.installed; do
 	if [[ ! ${extensions[*]} =~ ${key} ]]; then
 		echo "Uninstalling extension: ${key}"
 		/usr/local/bin/extension-installer \
-			-type ${STORAGE_TYPE} \
-			-region ${STORAGE_REGION} \
-			-bucket ${STORAGE_BUCKET} \
-			-extension-path ${PGDATA_EXTENSIONS} \
-			-key ${key} \
+			-type "${STORAGE_TYPE}" \
+			-region "${STORAGE_REGION}" \
+			-bucket "${STORAGE_BUCKET}" \
+			-extension-path "${PGDATA_EXTENSIONS}" \
+			-key "${key}" \
 			-uninstall
-		rm -f ${installed}
+		rm -f "${installed}"
 	fi
 done

--- a/build/postgres-operator/install-extensions.sh
+++ b/build/postgres-operator/install-extensions.sh
@@ -13,6 +13,7 @@ for key in "${extensions[@]}"; do
 	echo "Installing extension: ${key}"
 	/usr/local/bin/extension-installer \
 		-type ${STORAGE_TYPE} \
+		${STORAGE_ENDPOINT:+-endpoint "$STORAGE_ENDPOINT"} \
 		-region ${STORAGE_REGION} \
 		-bucket ${STORAGE_BUCKET} \
 		-extension-path ${PGDATA_EXTENSIONS} \

--- a/cmd/extension-installer/main.go
+++ b/cmd/extension-installer/main.go
@@ -11,10 +11,11 @@ import (
 )
 
 func main() {
-	var storageType, region, bucket, key, extensionPath string
+	var storageType, endpoint, region, bucket, key, extensionPath string
 	var install, uninstall bool
 
 	flag.StringVar(&storageType, "type", "", "Storage type")
+	flag.StringVar(&endpoint, "endpoint", "", "Storage endpoint")
 	flag.StringVar(&region, "region", "", "Storage region")
 	flag.StringVar(&bucket, "bucket", "", "Storage bucket")
 	flag.StringVar(&extensionPath, "extension-path", "", "Extension installation path")
@@ -30,7 +31,7 @@ func main() {
 
 	log.Printf("starting extension installer for %s/%s (%s) in %s", bucket, key, storageType, region)
 
-	storage := initStorage(extensions.StorageType(storageType), bucket, region)
+	storage := initStorage(extensions.StorageType(storageType), endpoint, bucket, region)
 
 	packageName := key + ".tar.gz"
 
@@ -69,10 +70,10 @@ func main() {
 	}
 }
 
-func initStorage(storageType extensions.StorageType, bucket, region string) extensions.ObjectGetter {
+func initStorage(storageType extensions.StorageType, endpoint, bucket, region string) extensions.ObjectGetter {
 	switch storageType {
 	case extensions.StorageTypeS3:
-		return extensions.NewS3(region, bucket)
+		return extensions.NewS3(endpoint, region, bucket)
 	default:
 		log.Fatalf("unknown storage type: %s", os.Getenv("STORAGE_TYPE"))
 	}

--- a/config/crd/bases/pgv2.percona.com_perconapgclusters.yaml
+++ b/config/crd/bases/pgv2.percona.com_perconapgclusters.yaml
@@ -7548,6 +7548,8 @@ spec:
                     properties:
                       bucket:
                         type: string
+                      endpoint:
+                        type: string
                       region:
                         type: string
                       secret:

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -7548,6 +7548,8 @@ spec:
                     properties:
                       bucket:
                         type: string
+                      endpoint:
+                        type: string
                       region:
                         type: string
                       secret:

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -7548,6 +7548,8 @@ spec:
                     properties:
                       bucket:
                         type: string
+                      endpoint:
+                        type: string
                       region:
                         type: string
                       secret:

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -7548,6 +7548,8 @@ spec:
                     properties:
                       bucket:
                         type: string
+                      endpoint:
+                        type: string
                       region:
                         type: string
                       secret:

--- a/docs/content/references/crd.md
+++ b/docs/content/references/crd.md
@@ -16610,6 +16610,11 @@ The specification of extensions.
         <td></td>
         <td>false</td>
       </tr><tr>
+        <td><b>endpoint</b></td>
+        <td>string</td>
+        <td></td>
+        <td>false</td>
+      </tr><tr>
         <td><b>region</b></td>
         <td>string</td>
         <td></td>

--- a/percona/controller/pgcluster/extensions.go
+++ b/percona/controller/pgcluster/extensions.go
@@ -56,6 +56,10 @@ func ExtensionInstallerContainer(postgresVersion int, spec *v2.ExtensionsSpec, e
 				Value: spec.Storage.Type,
 			},
 			{
+				Name:  "STORAGE_ENDPOINT",
+				Value: spec.Storage.Endpoint,
+			},
+			{
 				Name:  "STORAGE_REGION",
 				Value: spec.Storage.Region,
 			},

--- a/percona/extensions/s3.go
+++ b/percona/extensions/s3.go
@@ -15,8 +15,13 @@ type S3 struct {
 	svc *s3.S3
 }
 
-func NewS3(region, bucket string) *S3 {
+func NewS3(endpoint, region, bucket string) *S3 {
 	cfg := aws.NewConfig().WithRegion(region)
+
+	if endpoint != "" {
+		cfg = cfg.WithEndpoint(endpoint)
+	}
+
 	sess := session.Must(session.NewSession(cfg))
 	svc := s3.New(sess)
 

--- a/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
+++ b/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
@@ -423,10 +423,11 @@ type CustomExtensionSpec struct {
 
 type CustomExtensionsStorageSpec struct {
 	// +kubebuilder:validation:Enum={s3,gcs,azure}
-	Type   string                   `json:"type,omitempty"`
-	Bucket string                   `json:"bucket,omitempty"`
-	Region string                   `json:"region,omitempty"`
-	Secret *corev1.SecretProjection `json:"secret,omitempty"`
+	Type     string                   `json:"type,omitempty"`
+	Bucket   string                   `json:"bucket,omitempty"`
+	Region   string                   `json:"region,omitempty"`
+	Endpoint string                   `json:"endpoint,omitempty"`
+	Secret   *corev1.SecretProjection `json:"secret,omitempty"`
 }
 
 type BuiltInExtensionsSpec struct {


### PR DESCRIPTION
[![K8SPG-519](https://badgen.net/badge/JIRA/K8SPG-519/green)](https://jira.percona.com/browse/K8SPG-519) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
When installing custom extensions it is not possible to point to a custom s3 object storage endpoint.

**Cause:**
The s3 SDK within the extension installer is only minimally configured, currently using default values. 

**Solution:**
Add an optional flag to the extension installer named `endpoint` and configure the s3 SDK appropriately. 

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?