### PR TITLE
K8SPG-535: Panic on missing repo

### DIFF
--- a/percona/controller/pgbackup/controller.go
+++ b/percona/controller/pgbackup/controller.go
@@ -3,7 +3,6 @@ package pgbackup
 import (
 	"context"
 	"flag"
-	"fmt"
 	"io"
 	"path"
 	"strings"
@@ -104,7 +103,7 @@ func (r *PGBackupReconciler) Reconcile(ctx context.Context, request reconcile.Re
 
 		repo := getRepo(pgCluster, pgBackup)
 		if repo == nil {
-			return reconcile.Result{}, fmt.Errorf("%s repo not found", pgBackup.Spec.RepoName)
+			return reconcile.Result{}, errors.Errorf("%s repo not defined", pgBackup.Spec.RepoName)
 		}
 
 		pgBackup.Status.Repo = repo

--- a/percona/controller/pgbackup/controller.go
+++ b/percona/controller/pgbackup/controller.go
@@ -3,6 +3,7 @@ package pgbackup
 import (
 	"context"
 	"flag"
+	"fmt"
 	"io"
 	"path"
 	"strings"
@@ -100,7 +101,12 @@ func (r *PGBackupReconciler) Reconcile(ctx context.Context, request reconcile.Re
 
 		pgBackup.Status.Destination = getDestination(pgCluster, pgBackup)
 		pgBackup.Status.Image = pgCluster.Spec.Backups.PGBackRest.Image
+
 		repo := getRepo(pgCluster, pgBackup)
+		if repo == nil {
+			return reconcile.Result{}, fmt.Errorf("%s repo not found", pgBackup.Spec.RepoName)
+		}
+
 		pgBackup.Status.Repo = repo
 		switch {
 		case repo.S3 != nil:
@@ -216,14 +222,12 @@ func (r *PGBackupReconciler) Reconcile(ctx context.Context, request reconcile.Re
 
 func getRepo(pg *v2.PerconaPGCluster, pb *v2.PerconaPGBackup) *v1beta1.PGBackRestRepo {
 	repoName := pb.Spec.RepoName
-	var repo *v1beta1.PGBackRestRepo
 	for i, r := range pg.Spec.Backups.PGBackRest.Repos {
 		if repoName == r.Name {
-			repo = &pg.Spec.Backups.PGBackRest.Repos[i]
-			break
+			return &pg.Spec.Backups.PGBackRest.Repos[i]
 		}
 	}
-	return repo
+	return nil
 }
 
 func getDestination(pg *v2.PerconaPGCluster, pb *v2.PerconaPGBackup) string {


### PR DESCRIPTION
[![K8SPG-535](https://badgen.net/badge/JIRA/K8SPG-535/green)](https://jira.percona.com/browse/K8SPG-535) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
If you try to perform a backup with a repo not defined in the spec, the operator panics.

**Solution:**
Handle missing repo properly.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PG version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-535]: https://perconadev.atlassian.net/browse/K8SPG-535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ