### PR TITLE
K8SPG-583: Set correct operator version for version meta

### DIFF
--- a/percona/controller/pgcluster/version.go
+++ b/percona/controller/pgcluster/version.go
@@ -40,7 +40,7 @@ func (r *PGClusterReconciler) reconcileVersion(ctx context.Context, cr *v2.Perco
 func (r *PGClusterReconciler) getVersionMeta(cr *v2.PerconaPGCluster, operatorDepl *appsv1.Deployment) version.Meta {
 	vm := version.Meta{
 		Apply:           "disabled",
-		OperatorVersion: v2.Version,
+		OperatorVersion: cr.Spec.CRVersion,
 		CRUID:           string(cr.GetUID()),
 		KubeVersion:     r.KubeVersion,
 		Platform:        r.Platform,

--- a/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
+++ b/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
@@ -21,7 +21,7 @@ func init() {
 }
 
 const (
-	Version     = "2.2.0"
+	Version     = "2.4.0"
 	ProductName = "pg-operator"
 )
 


### PR DESCRIPTION
[![K8SPG-583](https://badgen.net/badge/JIRA/K8SPG-583/green)](https://jira.percona.com/browse/K8SPG-583) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
When setting `version.Meta` we set the hardcoded `v2.Version` operator version. We need to set `cr.Spec.CRVersion`.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PG version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-583]: https://perconadev.atlassian.net/browse/K8SPG-583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ