### PR TITLE
K8SPG-583 - Fix release version update in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -430,6 +430,7 @@ release: generate
 		-e "/^    pgbackrest:/,/^      image:/{s#image: .*#image: percona/percona-postgresql-operator:$(VERSION)-ppg$(PG_VER)-pgbackrest#}" \
 		-e "/extensions:/,/image:/{s#image: .*#image: percona/percona-postgresql-operator:$(VERSION)#}" \
 		-e "/^  pmm:/,/^    image:/{s#image: .*#image: percona/pmm-client:@@SET_TAG@@#}" deploy/cr.yaml
+	sed -i -r "/Version *= \"[0-9]+\.[0-9]+\.[0-9]+\"$$/ s/[0-9]+\.[0-9]+\.[0-9]+/$(VERSION)/" pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
 
 # Prepare main branch after release
 MAJOR_VER := $(shell grep -oE "crVersion: .*" deploy/cr.yaml|grep -oE "[0-9]+\.[0-9]+\.[0-9]+"|cut -d'.' -f1)
@@ -443,3 +444,4 @@ after-release: generate
 		-e "/^    pgbackrest:/,/^      image:/{s#image: .*#image: perconalab/percona-postgresql-operator:main-ppg$(PG_VER)-pgbackrest#}" \
 		-e "/extensions:/,/image:/{s#image: .*#image: perconalab/percona-postgresql-operator:main#}" \
 		-e "/^  pmm:/,/^    image:/{s#image: .*#image: perconalab/pmm-client:dev-latest#}" deploy/cr.yaml
+	sed -i -r "/Version *= \"[0-9]+\.[0-9]+\.[0-9]+\"$$/ s/[0-9]+\.[0-9]+\.[0-9]+/$(NEXT_VER)/" pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go


### PR DESCRIPTION
[![K8SPG-583](https://badgen.net/badge/JIRA/K8SPG-583/green)](https://jira.percona.com/browse/K8SPG-583) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*We were not setting the current version for releases in pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go*

**Solution:**
*Update the Makefile `release` and `after-release` targets*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PG version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-583]: https://perconadev.atlassian.net/browse/K8SPG-583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ