### PR TITLE
K8SPG-514 - Fix example for sysctls in cr.yaml

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -187,8 +187,10 @@ spec:
 #      supplementalGroups:
 #      - 1001
 #      sysctls:
-#      - net.ipv4.tcp_keepalive_time=600
-#      - net.ipv4.tcp_keepalive_intvl=60
+#      - name: net.ipv4.tcp_keepalive_time
+#        value: "600"
+#      - name: net.ipv4.tcp_keepalive_intvl
+#        value: "60"
 #
 #    walVolumeClaimSpec:
 #       storageClassName: standard
@@ -270,8 +272,10 @@ spec:
 #        supplementalGroups:
 #        - 1001
 #        sysctls:
-#        - net.ipv4.tcp_keepalive_time=600
-#        - net.ipv4.tcp_keepalive_intvl=60
+#        - name: net.ipv4.tcp_keepalive_time
+#          value: "600"
+#        - name: net.ipv4.tcp_keepalive_intvl
+#          value: "60"
 #
 #      topologySpreadConstraints:
 #        - maxSkew: 1
@@ -340,8 +344,10 @@ spec:
 #          supplementalGroups:
 #          - 1001
 #          sysctls:
-#          - net.ipv4.tcp_keepalive_time=600
-#          - net.ipv4.tcp_keepalive_intvl=60
+#          - name: net.ipv4.tcp_keepalive_time
+#            value: "600"
+#          - name: net.ipv4.tcp_keepalive_intvl
+#            value: "60"
 #
 #      global:
 #        repo1-retention-full: "14"
@@ -387,8 +393,10 @@ spec:
 #          supplementalGroups:
 #          - 1001
 #          sysctls:
-#          - net.ipv4.tcp_keepalive_time=600
-#          - net.ipv4.tcp_keepalive_intvl=60
+#          - name: net.ipv4.tcp_keepalive_time
+#            value: "600"
+#          - name: net.ipv4.tcp_keepalive_intvl
+#            value: "60"
 #
       manual:
         repoName: repo1


### PR DESCRIPTION
[![K8SPG-514](https://badgen.net/badge/JIRA/K8SPG-514/green)](https://jira.percona.com/browse/K8SPG-514) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*The example for sysctls in cr.yaml is wrong.*

**Solution:**
*Fix it as in: https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/#setting-sysctls-for-a-pod*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-514]: https://perconadev.atlassian.net/browse/K8SPG-514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ