### PR TITLE
K8SPG-492: Fix restore indentation in default cr.yaml

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -428,20 +428,13 @@ spec:
 #        azure:
 #          container: "<YOUR_AZURE_CONTAINER>"
 #
-#    restore:
-#      enabled: true
-#      repoName: repo1
-#      tolerations:
-#      - effect: NoSchedule
-#        key: role
-#        operator: Equal
-#        value: connection-poolers
-#      options:
-#       PITR restore in place
-#       - --type=time
-#       - --target="2021-06-09 14:15:11-04"
-#       restore individual databases
-#       - --db-include=hippo
+#      restore:
+#        repoName: repo1
+#        tolerations:
+#        - effect: NoSchedule
+#          key: role
+#          operator: Equal
+#          value: connection-poolers
 
   pmm:
     enabled: false


### PR DESCRIPTION
[![K8SPG-492](https://badgen.net/badge/JIRA/K8SPG-492/green)](https://jira.percona.com/browse/K8SPG-492) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Indentation was wrong.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PG version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-492]: https://perconadev.atlassian.net/browse/K8SPG-492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ