### PR TITLE
K8SPG-518: Don't set latest restorable time if it's earlier than backup start

### DIFF
--- a/e2e-tests/tests/pitr/07-assert.yaml
+++ b/e2e-tests/tests/pitr/07-assert.yaml
@@ -1,0 +1,31 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 560
+---
+kind: Job
+apiVersion: batch/v1
+metadata:
+  annotations:
+    postgres-operator.crunchydata.com/pgbackrest-backup: pitr-full-2
+  labels:
+    postgres-operator.crunchydata.com/pgbackrest-backup: manual
+    postgres-operator.crunchydata.com/pgbackrest-repo: repo1
+  ownerReferences:
+    - apiVersion: pgv2.percona.com/v2
+      kind: PerconaPGBackup
+      controller: true
+      blockOwnerDeletion: true
+status:
+  succeeded: 1
+---
+apiVersion: pgv2.percona.com/v2
+kind: PerconaPGBackup
+metadata:
+  name: pitr-full-2
+spec:
+  pgCluster: pitr
+  repoName: repo1
+  options:
+    - --type=full
+status:
+  state: Succeeded

--- a/e2e-tests/tests/pitr/07-create-backup.yaml
+++ b/e2e-tests/tests/pitr/07-create-backup.yaml
@@ -1,0 +1,9 @@
+apiVersion: pgv2.percona.com/v2
+kind: PerconaPGBackup
+metadata:
+  name: pitr-full-2
+spec:
+  pgCluster: pitr
+  repoName: repo1
+  options:
+    - --type=full

--- a/e2e-tests/tests/pitr/08-ensure-latest-restorable-time-doesnt-exist.yaml
+++ b/e2e-tests/tests/pitr/08-ensure-latest-restorable-time-doesnt-exist.yaml
@@ -1,0 +1,18 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+      
+      sleep 140 # sleep for 2 x archive_timeout + 20 seconds for good measure
+      
+      latest_restorable_time=$(kubectl -n ${NAMESPACE} get pg-backup pitr-full-2 -o json | jq '.status.latestRestorableTime')
+      
+      if [ "${latest_restorable_time}" != "null" ]; then
+        echo "latest restorable time should be null"
+        exit 1
+      fi
+    timeout: 150

--- a/percona/controller/pgbackup/controller.go
+++ b/percona/controller/pgbackup/controller.go
@@ -229,7 +229,7 @@ func (r *PGBackupReconciler) Reconcile(ctx context.Context, request reconcile.Re
 			return reconcile.Result{}, errors.Wrap(err, "failed to create exec client")
 		}
 
-		latestRestorableTime, err := watcher.GetLatestCommitTimestamp(ctx, r.Client, execCli, pgCluster)
+		latestRestorableTime, err := watcher.GetLatestCommitTimestamp(ctx, r.Client, execCli, pgCluster, pgBackup)
 		if err == nil {
 			log.Info("Got latest restorable timestamp", "timestamp", latestRestorableTime)
 			pgBackup.Status.LatestRestorableTime.Time = latestRestorableTime

--- a/percona/pgbackrest/pgbackrest.go
+++ b/percona/pgbackrest/pgbackrest.go
@@ -21,6 +21,10 @@ type InfoBackup struct {
 	Annotation map[string]string `json:"annotation,omitempty"`
 	Label      string            `json:"label,omitempty"`
 	Type       v2.PGBackupType   `json:"type,omitempty"`
+	Timestamp  struct {
+		Start int64 `json:"start,omitempty"`
+		Stop  int64 `json:"stop,omitempty"`
+	} `json:"timestamp,omitempty"`
 }
 
 type InfoStanza struct {


### PR DESCRIPTION
[![K8SPG-518](https://badgen.net/badge/JIRA/K8SPG-518/green)](https://jira.percona.com/browse/K8SPG-518) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
We were setting latest restorable time to backup even though there are no new transactions committed to database.

**Solution:**
Check if latest restorable time is earlier than backup start timestamp and don't set it to backup if it's.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PG version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-518]: https://perconadev.atlassian.net/browse/K8SPG-518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ