### PR TITLE
K8SPG-595: set `.spec.extensions.image` field as required

### DIFF
--- a/build/crd/percona/generated/pgv2.percona.com_perconapgclusters.yaml
+++ b/build/crd/percona/generated/pgv2.percona.com_perconapgclusters.yaml
@@ -8068,6 +8068,8 @@ spec:
                         - azure
                         type: string
                     type: object
+                required:
+                - image
                 type: object
               image:
                 description: The image name to use for PostgreSQL containers.

--- a/config/crd/bases/pgv2.percona.com_perconapgclusters.yaml
+++ b/config/crd/bases/pgv2.percona.com_perconapgclusters.yaml
@@ -8473,6 +8473,8 @@ spec:
                         - azure
                         type: string
                     type: object
+                required:
+                - image
                 type: object
               image:
                 description: The image name to use for PostgreSQL containers.

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -8778,6 +8778,8 @@ spec:
                         - azure
                         type: string
                     type: object
+                required:
+                - image
                 type: object
               image:
                 description: The image name to use for PostgreSQL containers.

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -8778,6 +8778,8 @@ spec:
                         - azure
                         type: string
                     type: object
+                required:
+                - image
                 type: object
               image:
                 description: The image name to use for PostgreSQL containers.

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -8778,6 +8778,8 @@ spec:
                         - azure
                         type: string
                     type: object
+                required:
+                - image
                 type: object
               image:
                 description: The image name to use for PostgreSQL containers.

--- a/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
+++ b/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
@@ -539,7 +539,8 @@ type BuiltInExtensionsSpec struct {
 }
 
 type ExtensionsSpec struct {
-	Image           string                      `json:"image,omitempty"`
+	// +kubebuilder:validation:Required
+	Image           string                      `json:"image"`
 	ImagePullPolicy corev1.PullPolicy           `json:"imagePullPolicy,omitempty"`
 	Storage         CustomExtensionsStorageSpec `json:"storage,omitempty"`
 	BuiltIn         BuiltInExtensionsSpec       `json:"builtin,omitempty"`


### PR DESCRIPTION
[![K8SPG-595](https://badgen.net/badge/JIRA/K8SPG-595/green)](https://jira.percona.com/browse/K8SPG-595) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPG-595

**DESCRIPTION**
---
This PR sets `.spec.extensions.image` field as required

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PG version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-595]: https://perconadev.atlassian.net/browse/K8SPG-595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ