### PR TITLE
K8SPG-600: Fix failed backup status

### DIFF
--- a/config/rbac/cluster/role.yaml
+++ b/config/rbac/cluster/role.yaml
@@ -181,6 +181,7 @@ rules:
   resources:
   - crunchybridgeclusters/finalizers
   - crunchybridgeclusters/status
+  - postgresclusters/status
   verbs:
   - patch
   - update
@@ -205,7 +206,6 @@ rules:
   resources:
   - pgadmins/status
   - pgupgrades/status
-  - postgresclusters/status
   verbs:
   - patch
 - apiGroups:

--- a/config/rbac/namespace/role.yaml
+++ b/config/rbac/namespace/role.yaml
@@ -181,6 +181,7 @@ rules:
   resources:
   - crunchybridgeclusters/finalizers
   - crunchybridgeclusters/status
+  - postgresclusters/status
   verbs:
   - patch
   - update
@@ -205,7 +206,6 @@ rules:
   resources:
   - pgadmins/status
   - pgupgrades/status
-  - postgresclusters/status
   verbs:
   - patch
 - apiGroups:

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -45321,6 +45321,7 @@ rules:
   resources:
   - crunchybridgeclusters/finalizers
   - crunchybridgeclusters/status
+  - postgresclusters/status
   verbs:
   - patch
   - update
@@ -45345,7 +45346,6 @@ rules:
   resources:
   - pgadmins/status
   - pgupgrades/status
-  - postgresclusters/status
   verbs:
   - patch
 - apiGroups:

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -45321,6 +45321,7 @@ rules:
   resources:
   - crunchybridgeclusters/finalizers
   - crunchybridgeclusters/status
+  - postgresclusters/status
   verbs:
   - patch
   - update
@@ -45345,7 +45346,6 @@ rules:
   resources:
   - pgadmins/status
   - pgupgrades/status
-  - postgresclusters/status
   verbs:
   - patch
 - apiGroups:

--- a/deploy/cw-rbac.yaml
+++ b/deploy/cw-rbac.yaml
@@ -185,6 +185,7 @@ rules:
   resources:
   - crunchybridgeclusters/finalizers
   - crunchybridgeclusters/status
+  - postgresclusters/status
   verbs:
   - patch
   - update
@@ -209,7 +210,6 @@ rules:
   resources:
   - pgadmins/status
   - pgupgrades/status
-  - postgresclusters/status
   verbs:
   - patch
 - apiGroups:

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -185,6 +185,7 @@ rules:
   resources:
   - crunchybridgeclusters/finalizers
   - crunchybridgeclusters/status
+  - postgresclusters/status
   verbs:
   - patch
   - update
@@ -209,7 +210,6 @@ rules:
   resources:
   - pgadmins/status
   - pgupgrades/status
-  - postgresclusters/status
   verbs:
   - patch
 - apiGroups:

--- a/internal/controller/postgrescluster/controller.go
+++ b/internal/controller/postgrescluster/controller.go
@@ -79,7 +79,7 @@ type Reconciler struct {
 
 // +kubebuilder:rbac:groups="",resources="events",verbs={create,patch}
 // +kubebuilder:rbac:groups="postgres-operator.crunchydata.com",resources="postgresclusters",verbs={get,list,watch}
-// +kubebuilder:rbac:groups="postgres-operator.crunchydata.com",resources="postgresclusters/status",verbs={patch}
+// +kubebuilder:rbac:groups="postgres-operator.crunchydata.com",resources="postgresclusters/status",verbs={patch,update}
 
 // Reconcile reconciles a ConfigMap in a namespace managed by the PostgreSQL Operator
 func (r *Reconciler) Reconcile(

--- a/percona/controller/pgcluster/controller.go
+++ b/percona/controller/pgcluster/controller.go
@@ -36,6 +36,7 @@ import (
 	perconaController "github.com/percona/percona-postgresql-operator/percona/controller"
 	"github.com/percona/percona-postgresql-operator/percona/extensions"
 	"github.com/percona/percona-postgresql-operator/percona/k8s"
+	pNaming "github.com/percona/percona-postgresql-operator/percona/naming"
 	"github.com/percona/percona-postgresql-operator/percona/pmm"
 	"github.com/percona/percona-postgresql-operator/percona/utils/registry"
 	"github.com/percona/percona-postgresql-operator/percona/watcher"
@@ -337,7 +338,7 @@ func (r *PGClusterReconciler) addPMMSidecar(ctx context.Context, cr *v2.PerconaP
 		if set.Metadata.Annotations == nil {
 			set.Metadata.Annotations = make(map[string]string)
 		}
-		set.Metadata.Annotations[v2.AnnotationPMMSecretHash] = pmmSecretHash
+		set.Metadata.Annotations[pNaming.AnnotationPMMSecretHash] = pmmSecretHash
 
 		set.Sidecars = append(set.Sidecars, pmm.SidecarContainer(cr))
 	}
@@ -381,7 +382,7 @@ func (r *PGClusterReconciler) handleMonitorUserPassChange(ctx context.Context, c
 		}
 
 		// If the currentHash is the same  is the on the STS, restart will not  happen
-		set.Metadata.Annotations[v2.AnnotationMonitorUserSecretHash] = currentHash
+		set.Metadata.Annotations[pNaming.AnnotationMonitorUserSecretHash] = currentHash
 	}
 
 	return nil

--- a/percona/controller/pgcluster/controller_test.go
+++ b/percona/controller/pgcluster/controller_test.go
@@ -25,6 +25,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	pNaming "github.com/percona/percona-postgresql-operator/percona/naming"
 	"github.com/percona/percona-postgresql-operator/internal/controller/postgrescluster"
 	"github.com/percona/percona-postgresql-operator/internal/controller/runtime"
 	"github.com/percona/percona-postgresql-operator/internal/naming"
@@ -257,7 +258,7 @@ var _ = Describe("PMM sidecar", Ordered, func() {
 
 			It("should have PMM secret hash", func() {
 				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&sts), &sts)).Should(Succeed())
-				Expect(sts.Spec.Template.ObjectMeta.Annotations).To(HaveKey(v2.AnnotationPMMSecretHash))
+				Expect(sts.Spec.Template.ObjectMeta.Annotations).To(HaveKey(pNaming.AnnotationPMMSecretHash))
 			})
 
 			It("should label PMM secret", func() {
@@ -383,7 +384,7 @@ var _ = Describe("Monitor user password change", Ordered, func() {
 
 			Expect(stsList.Items).Should(ContainElement(gs.MatchFields(gs.IgnoreExtras, gs.Fields{
 				"ObjectMeta": gs.MatchFields(gs.IgnoreExtras, gs.Fields{
-					"Annotations": HaveKeyWithValue(v2.AnnotationMonitorUserSecretHash, currentHash),
+					"Annotations": HaveKeyWithValue(pNaming.AnnotationMonitorUserSecretHash, currentHash),
 				}),
 			})))
 		})
@@ -416,7 +417,7 @@ var _ = Describe("Monitor user password change", Ordered, func() {
 
 			Expect(stsList.Items).Should(ContainElement(gs.MatchFields(gs.IgnoreExtras, gs.Fields{
 				"ObjectMeta": gs.MatchFields(gs.IgnoreExtras, gs.Fields{
-					"Annotations": HaveKeyWithValue(v2.AnnotationMonitorUserSecretHash, currentHash),
+					"Annotations": HaveKeyWithValue(pNaming.AnnotationMonitorUserSecretHash, currentHash),
 				}),
 			})))
 		})

--- a/percona/controller/pgcluster/controller_test.go
+++ b/percona/controller/pgcluster/controller_test.go
@@ -25,11 +25,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	pNaming "github.com/percona/percona-postgresql-operator/percona/naming"
 	"github.com/percona/percona-postgresql-operator/internal/controller/postgrescluster"
 	"github.com/percona/percona-postgresql-operator/internal/controller/runtime"
 	"github.com/percona/percona-postgresql-operator/internal/naming"
 	perconaController "github.com/percona/percona-postgresql-operator/percona/controller"
+	pNaming "github.com/percona/percona-postgresql-operator/percona/naming"
 	v2 "github.com/percona/percona-postgresql-operator/pkg/apis/pgv2.percona.com/v2"
 	"github.com/percona/percona-postgresql-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )

--- a/percona/naming/annotations.go
+++ b/percona/naming/annotations.go
@@ -1,0 +1,61 @@
+package util
+
+import (
+	"strings"
+)
+
+const (
+	AnnotationPrefix        = "pgv2.percona.com/"
+	CrunchyAnnotationPrefix = "postgres-operator.crunchydata.com/"
+)
+
+const (
+	// AnnotationPGBackrestBackup is the annotation that is added to a PerconaPGCluster to initiate a manual
+	// backup.  The value of the annotation will be a unique identifier for a backup Job (e.g. a
+	// timestamp), which will be stored in the PostgresCluster status to properly track completion
+	// of the Job.  Also used to annotate the backup Job itself as needed to identify the backup
+	// ID associated with a specific manual backup Job.
+	AnnotationPGBackrestBackup = AnnotationPrefix + "pgbackrest-backup"
+
+	// AnnotationPGBackrestBackupJobName is the annotation that is added to a PerconaPGClusterBackup.
+	// The value of the annotation will be a name of an existing backup job
+	AnnotationPGBackrestBackupJobName = AnnotationPGBackrestBackup + "-job-name"
+
+	// AnnotationPGBackrestBackupJobType is the annotation that is added to a PerconaPGClusterBackup.
+	// The value of the annotation will be a type of a backup (e.g. "manual" or "replica-create).
+	AnnotationPGBackrestBackupJobType = AnnotationPGBackrestBackup + "-job-type"
+
+	// AnnotationPGBackRestRestore is the annotation that is added to a PerconaPGCluster to initiate an in-place
+	// restore.  The value of the annotation will be a unique identfier for a restore Job (e.g. a
+	// timestamp), which will be stored in the PostgresCluster status to properly track completion
+	// of the Job.
+	AnnotationPGBackRestRestore = AnnotationPrefix + "pgbackrest-restore"
+
+	// AnnotationPMMSecretHash is the annotation that is added to instance annotations to
+	// rollout restart PG pods in case PMM credentials are rotated.
+	AnnotationPMMSecretHash = AnnotationPrefix + "pmm-secret-hash"
+
+	// AnnotationMonitorUserSecretHash is the annotation that is added to instance annotations to
+	// rollout restart PG pods in case monitor user password is changed.
+	AnnotationMonitorUserSecretHash = AnnotationPrefix + "monitor-user-secret-hash"
+
+	// AnnotationBackupInProgress is the annotation that is added to PerconaPGCluster to
+	// indicate that backup is in progress.
+	AnnotationBackupInProgress = AnnotationPrefix + "backup-in-progress"
+)
+
+func ToCrunchyAnnotation(annotation string) string {
+	return replacePrefix(annotation, AnnotationPrefix, CrunchyAnnotationPrefix)
+}
+
+func ToPerconaAnnotation(annotation string) string {
+	return replacePrefix(annotation, CrunchyAnnotationPrefix, AnnotationPrefix)
+}
+
+func replacePrefix(s, oldPrefix, newPrefix string) string {
+	s, found := strings.CutPrefix(s, oldPrefix)
+	if found {
+		return newPrefix + s
+	}
+	return s
+}

--- a/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
+++ b/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
@@ -3,7 +3,6 @@ package v2
 import (
 	"context"
 	"os"
-	"strings"
 
 	gover "github.com/hashicorp/go-version"
 	v "github.com/hashicorp/go-version"
@@ -14,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/percona/percona-postgresql-operator/internal/logging"
+	pNaming "github.com/percona/percona-postgresql-operator/percona/naming"
 	crunchyv1beta1 "github.com/percona/percona-postgresql-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
@@ -241,12 +241,7 @@ func (cr *PerconaPGCluster) ToCrunchy(ctx context.Context, postgresCluster *crun
 		case corev1.LastAppliedConfigAnnotation:
 			continue
 		default:
-			if strings.HasPrefix(k, AnnotationPrefix) {
-				a := strings.Split(k, "/")
-				annotations[CrunchyAnnotationPrefix+a[1]] = v
-			} else {
-				annotations[k] = v
-			}
+			annotations[pNaming.ToCrunchyAnnotation(k)] = v
 		}
 	}
 	postgresCluster.Annotations = annotations
@@ -906,46 +901,6 @@ const labelPrefix = "pgv2.percona.com/"
 const (
 	LabelOperatorVersion = labelPrefix + "version"
 	LabelPMMSecret       = labelPrefix + "pmm-secret"
-)
-
-const (
-	AnnotationPrefix        = "pgv2.percona.com/"
-	CrunchyAnnotationPrefix = "postgres-operator.crunchydata.com/"
-)
-
-const (
-	// AnnotationPGBackrestBackup is the annotation that is added to a PerconaPGCluster to initiate a manual
-	// backup.  The value of the annotation will be a unique identifier for a backup Job (e.g. a
-	// timestamp), which will be stored in the PostgresCluster status to properly track completion
-	// of the Job.  Also used to annotate the backup Job itself as needed to identify the backup
-	// ID associated with a specific manual backup Job.
-	AnnotationPGBackrestBackup = AnnotationPrefix + "pgbackrest-backup"
-
-	// AnnotationPGBackrestBackupJobName is the annotation that is added to a PerconaPGClusterBackup.
-	// The value of the annotation will be a name of an existing backup job
-	AnnotationPGBackrestBackupJobName = AnnotationPGBackrestBackup + "-job-name"
-
-	// AnnotationPGBackrestBackupJobType is the annotation that is added to a PerconaPGClusterBackup.
-	// The value of the annotation will be a type of a backup (e.g. "manual" or "replica-create).
-	AnnotationPGBackrestBackupJobType = AnnotationPGBackrestBackup + "-job-type"
-
-	// AnnotationPGBackRestRestore is the annotation that is added to a PerconaPGCluster to initiate an in-place
-	// restore.  The value of the annotation will be a unique identfier for a restore Job (e.g. a
-	// timestamp), which will be stored in the PostgresCluster status to properly track completion
-	// of the Job.
-	AnnotationPGBackRestRestore = AnnotationPrefix + "pgbackrest-restore"
-
-	// AnnotationPMMSecretHash is the annotation that is added to instance annotations to
-	// rollout restart PG pods in case PMM credentials are rotated.
-	AnnotationPMMSecretHash = AnnotationPrefix + "pmm-secret-hash"
-
-	// AnnotationMonitorUserSecretHash is the annotation that is added to instance annotations to
-	// rollout restart PG pods in case monitor user password is changed.
-	AnnotationMonitorUserSecretHash = AnnotationPrefix + "monitor-user-secret-hash"
-
-	// AnnotationBackupInProgress is the annotation that is added to PerconaPGCluster to
-	// indicate that backup is in progress.
-	AnnotationBackupInProgress = AnnotationPrefix + "backup-in-progress"
 )
 
 const DefaultVersionServiceEndpoint = "https://check.percona.com"


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/K8SPG-600

**DESCRIPTION**
---
**Problem:**
*If the user has the wrong `pgbackrest` credentials, the failed backup doesn't get the `failed` state in the `pg-backup` `.status.`*.

**Reason:**
*When incorrect `pgbackrest` credentials are used, the pg cluster reconcile fails, which stops the process of updating crunchy's `postgrescluster` resource. It is necessary to delete backup annotations from crunchy's resource, and this problem doesn't allow it to continue.*

**Solution:**
*Don't stop the reconcile process with the `pgbackrest` error. Log the error message instead. Also, the operator should avoid trying to use `pgbackrest` when the backup job has failed.*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PG version?
- [x] Does the change support oldest and newest supported Kubernetes version?