### PR TITLE
K8SPG-597 Fixing test case upgrade-minor to work with postures images which have minor numbers in the image name

### DIFF
--- a/e2e-tests/tests/upgrade-minor/01-create-cluster.yaml
+++ b/e2e-tests/tests/upgrade-minor/01-create-cluster.yaml
@@ -13,25 +13,25 @@ commands:
       curl -s "https://raw.githubusercontent.com/percona/percona-postgresql-operator/v${lower_ver}/deploy/cr.yaml" >"${TEMP_DIR}/cr_lower.yaml"
 
       # get PG version which we want to test
-      pg_ver=$(echo "$IMAGE_POSTGRESQL" | cut -d':' -f2 | grep -oE '\-ppg[0-9]+-' | grep -oE '[0-9]+' | tr -d '-')
+      pg_ver=$PG_VER
       pg_exists=0
-      pg_exists=$(curl -s https://check.percona.com/versions/v1/pg-operator/${lower_ver} | jq '.versions[].matrix.postgresql | with_entries(select(.key | startswith("'${pg_ver}'"))) | length')
+      pg_exists=$(curl -s https://check.percona.com/versions/v1/pg-operator/${lower_ver} | jq '.versions[].matrix.postgresql | with_entries(select(.key | startswith("'$pg_ver'"))) | length')
       # if the lower version of operator doesn't have new PG version we will use lower PG version
       # but in that case not the intended targer PG database image will be tested
       # (this should happen once a year on major PG version release, but only for this latest version)
       if [ $pg_exists -eq 0 ]; then
           pg_ver=$((pg_ver - 1))
       fi
-      echo "${pg_ver}" >"${TEMP_DIR}/pg_ver.txt"
+      echo $pg_ver >"${TEMP_DIR}/pg_ver.txt"
 
       yq -i eval '
           .metadata.name = "'${test_name}'" |
           .metadata.labels = {"e2e":"'${test_name}'"} |
-          .spec.image = "percona/percona-postgresql-operator:'${lower_ver}'-ppg'${pg_ver}'-postgres" |
-          .spec.postgresVersion = '${pg_ver}' |
-          .spec.proxy.pgBouncer.image = "percona/percona-postgresql-operator:'${lower_ver}'-ppg'${pg_ver}'-pgbouncer" |
+          .spec.image = "percona/percona-postgresql-operator:'${lower_ver}'-ppg'$pg_ver'-postgres" |
+          .spec.postgresVersion = '$pg_ver' |
+          .spec.proxy.pgBouncer.image = "percona/percona-postgresql-operator:'${lower_ver}'-ppg'$pg_ver'-pgbouncer" |
           .spec.backups.pgbackrest.repos[0].schedules = null |
-          .spec.backups.pgbackrest.image = "percona/percona-postgresql-operator:'${lower_ver}'-ppg'${pg_ver}'-pgbackrest" |
+          .spec.backups.pgbackrest.image = "percona/percona-postgresql-operator:'${lower_ver}'-ppg'$pg_ver'-pgbackrest" |
           .spec.users += [{"name":"postgres","password":{"type":"AlphaNumeric"}}] |
           .spec.users += [{"name":"'${test_name}'","password":{"type":"AlphaNumeric"}}]' "${TEMP_DIR}/cr_lower.yaml"
       kubectl -n "${NAMESPACE}" apply -f "${TEMP_DIR}/cr_lower.yaml"

--- a/e2e-tests/tests/upgrade-minor/05-upgrade-cluster.yaml
+++ b/e2e-tests/tests/upgrade-minor/05-upgrade-cluster.yaml
@@ -8,15 +8,15 @@ commands:
       source ../../functions
 
       pg_ver_lower="$(cat ${TEMP_DIR}/pg_ver.txt)"
-      pg_ver_upper=$(echo "$IMAGE_POSTGRESQL" | cut -d':' -f2 | grep -oE '\-ppg[0-9]+-' | grep -oE '[0-9]+' | tr -d '-')
+      pg_ver_upper=$PG_VER
       target_image_postgresql=$IMAGE_POSTGRESQL
       target_image_pgbouncer=$IMAGE_PGBOUNCER
       target_image_backrest=$IMAGE_BACKREST
 
-      if [ "${pg_ver_lower}" != "${pg_ver_upper}" ]; then
-          target_image_postgresql="perconalab/percona-postgresql-operator:main-ppg${pg_ver_lower}-postgres"
-          target_image_pgbouncer="perconalab/percona-postgresql-operator:main-ppg${pg_ver_lower}-pgbouncer"
-          target_image_backrest="perconalab/percona-postgresql-operator:main-ppg${pg_ver_lower}-pgbackrest"
+      if [ "$pg_ver_lower" != "$pg_ver_upper" ]; then
+          target_image_postgresql="perconalab/percona-postgresql-operator:main-ppg$pg_ver_lower-postgres"
+          target_image_pgbouncer="perconalab/percona-postgresql-operator:main-ppg$pg_ver_lower-pgbouncer"
+          target_image_backrest="perconalab/percona-postgresql-operator:main-ppg$pg_ver_lower-pgbackrest"
       fi
       cr_ver=$(yq '.spec.crVersion' $DEPLOY_DIR/cr.yaml)
 

--- a/e2e-tests/tests/upgrade-minor/05-upgrade-cluster.yaml
+++ b/e2e-tests/tests/upgrade-minor/05-upgrade-cluster.yaml
@@ -8,12 +8,11 @@ commands:
       source ../../functions
 
       pg_ver_lower="$(cat ${TEMP_DIR}/pg_ver.txt)"
-      pg_ver_upper=$PG_VER
       target_image_postgresql=$IMAGE_POSTGRESQL
       target_image_pgbouncer=$IMAGE_PGBOUNCER
       target_image_backrest=$IMAGE_BACKREST
 
-      if [ "$pg_ver_lower" != "$pg_ver_upper" ]; then
+      if [ "$pg_ver_lower" != "$PG_VER" ]; then
           target_image_postgresql="perconalab/percona-postgresql-operator:main-ppg$pg_ver_lower-postgres"
           target_image_pgbouncer="perconalab/percona-postgresql-operator:main-ppg$pg_ver_lower-pgbouncer"
           target_image_backrest="perconalab/percona-postgresql-operator:main-ppg$pg_ver_lower-pgbackrest"


### PR DESCRIPTION
[![K8SPG-597](https://badgen.net/badge/JIRA/K8SPG-597/green)](https://jira.percona.com/browse/K8SPG-597) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
The test case upgrade-minor fails when the `PGO_POSTGRES_IMAGE` contains an image with minor version, e.g. `percona/percona-postgresql-operator:2.4.0-ppg16.3-postgres`. Now I use the `PG_VER` env var.

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-597]: https://perconadev.atlassian.net/browse/K8SPG-597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ