### PR TITLE
K8SPG-597 - Update monitoring test

### DIFF
--- a/e2e-tests/tests/monitoring/04-assert.yaml
+++ b/e2e-tests/tests/monitoring/04-assert.yaml
@@ -1,3 +1,21 @@
+apiVersion: pgv2.percona.com/v2
+kind: PerconaPGCluster
+metadata:
+  labels:
+    e2e: monitoring
+  name: monitoring
+status:
+  pgbouncer:
+    ready: 3
+    size: 3
+  postgres:
+    instances:
+      - name: instance1
+        ready: 3
+        size: 3
+    ready: 3
+    size: 3
+  state: ready
 ---
 apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster
@@ -14,6 +32,26 @@ status:
       replicas: 3
       updatedReplicas: 3
 ---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: monitoring
+    postgres-operator.crunchydata.com/data: postgres
+    postgres-operator.crunchydata.com/instance-set: instance1
+  ownerReferences:
+    - apiVersion: postgres-operator.crunchydata.com/v1beta1
+      kind: PostgresCluster
+      name: monitoring
+      controller: true
+      blockOwnerDeletion: true
+status:
+  observedGeneration: 3
+  replicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1
+  collisionCount: 0
+---
 kind: Pod
 apiVersion: v1
 metadata:
@@ -27,12 +65,3 @@ metadata:
       kind: StatefulSet
 status:
   phase: Running
-  conditions:
-    - type: Initialized
-      status: 'True'
-    - type: Ready
-      status: 'True'
-    - type: ContainersReady
-      status: 'True'
-    - type: PodScheduled
-      status: 'True'


### PR DESCRIPTION
[![K8SPG-597](https://badgen.net/badge/JIRA/K8SPG-597/green)](https://jira.percona.com/browse/K8SPG-597) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*In one position in the test we were checking for Pod status conditions (array) and Kubernetes 1.29 adds a new status `PodReadyToStartContainers`. Unfortunately `kuttl` cannot compare arrays of different sizes so the test fails on 1.29. On the other hand I don't think checking for these status conditions in this place tests anything since any pod running will have all these conditions True.*

**Solution:**
*I have removed checking for status conditions and just left checking for Running phase and also added checking for sts statuses.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-597]: https://perconadev.atlassian.net/browse/K8SPG-597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ