### PR TITLE
K8SPG-254: Fix major upgrade on Openshift

### DIFF
--- a/config/rbac/cluster/role.yaml
+++ b/config/rbac/cluster/role.yaml
@@ -143,6 +143,7 @@ rules:
   resources:
   - perconapgclusters/status
   - perconapgrestores/status
+  - perconapgupgrades/finalizers
   - perconapgupgrades/status
   verbs:
   - patch

--- a/config/rbac/namespace/role.yaml
+++ b/config/rbac/namespace/role.yaml
@@ -143,6 +143,7 @@ rules:
   resources:
   - perconapgclusters/status
   - perconapgrestores/status
+  - perconapgupgrades/finalizers
   - perconapgupgrades/status
   verbs:
   - patch

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -45283,6 +45283,7 @@ rules:
   resources:
   - perconapgclusters/status
   - perconapgrestores/status
+  - perconapgupgrades/finalizers
   - perconapgupgrades/status
   verbs:
   - patch

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -45283,6 +45283,7 @@ rules:
   resources:
   - perconapgclusters/status
   - perconapgrestores/status
+  - perconapgupgrades/finalizers
   - perconapgupgrades/status
   verbs:
   - patch

--- a/deploy/cw-rbac.yaml
+++ b/deploy/cw-rbac.yaml
@@ -147,6 +147,7 @@ rules:
   resources:
   - perconapgclusters/status
   - perconapgrestores/status
+  - perconapgupgrades/finalizers
   - perconapgupgrades/status
   verbs:
   - patch

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -147,6 +147,7 @@ rules:
   resources:
   - perconapgclusters/status
   - perconapgrestores/status
+  - perconapgupgrades/finalizers
   - perconapgupgrades/status
   verbs:
   - patch

--- a/percona/controller/pgupgrade/controller.go
+++ b/percona/controller/pgupgrade/controller.go
@@ -41,6 +41,7 @@ func (r *PGUpgradeReconciler) SetupWithManager(mgr manager.Manager) error {
 
 // +kubebuilder:rbac:groups=pgv2.percona.com,resources=perconapgupgrades,verbs=get;list;create;update;patch;watch
 // +kubebuilder:rbac:groups=pgv2.percona.com,resources=perconapgupgrades/status,verbs=patch;update
+// +kubebuilder:rbac:groups=pgv2.percona.com,resources=perconapgupgrades/finalizers,verbs=patch;update
 // +kubebuilder:rbac:groups=pgv2.percona.com,resources=perconapgclusters,verbs=get;list;watch;patch;update
 // +kubebuilder:rbac:groups=postgres-operator.crunchydata.com,resources=pgupgrades,verbs=get;list;create;update;patch;delete;watch
 


### PR DESCRIPTION
[![K8SPG-254](https://badgen.net/badge/JIRA/K8SPG-254/green)](https://jira.percona.com/browse/K8SPG-254) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
```
create PGUpgrade: pgupgrades.postgres-operator.crunchydata.com "12-to-13" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
```

**Cause:**
Operator needs to permission to upgrade `PerconaPGUpgrade` finalizers.

**Solution:**
Add permission.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PG version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-254]: https://perconadev.atlassian.net/browse/K8SPG-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ