### PR TITLE
K8SPG-616: Fix stuck operator after cluster deletion

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -122,18 +122,19 @@ get_client_pod() {
 
 get_cr() {
 	local name_suffix=$1
+	local cr_name="${test_name}${name_suffix}"
 
 	yq eval '
-		.metadata.name = "'$test_name'" |
-		.metadata.labels = {"e2e":"'$test_name'"} |
+		.metadata.name = "'${cr_name}'" |
+		.metadata.labels = {"e2e":"'${cr_name}'"} |
 		.spec.postgresVersion = '$PG_VER' |
 		.spec.users += [{"name":"postgres","password":{"type":"AlphaNumeric"}}] |
-		.spec.users += [{"name":"'$test_name'","password":{"type":"AlphaNumeric"}}] |
+		.spec.users += [{"name":"'${cr_name}'","password":{"type":"AlphaNumeric"}}] |
 		.spec.image = "'$IMAGE_POSTGRESQL'" |
 		.spec.backups.pgbackrest.image = "'$IMAGE_BACKREST'" |
 		.spec.proxy.pgBouncer.image = "'$IMAGE_PGBOUNCER'" |
 		.spec.pmm.image = "'$IMAGE_PMM_CLIENT'" |
-		.spec.pmm.secret = "'$test_name'-pmm-secret"
+		.spec.pmm.secret = "'${cr_name}'-pmm-secret"
 		' $DEPLOY_DIR/cr.yaml >$TEMP_DIR/cr.yaml
 
 	if [[ $OPENSHIFT ]]; then
@@ -143,16 +144,16 @@ get_cr() {
 	case $test_name in
 		"demand-backup" | "start-from-backup")
 			yq eval -i '
-				.spec.backups.pgbackrest.configuration = [{"secret":{"name":"'$test_name'-pgbackrest-secrets"}}] |
+				.spec.backups.pgbackrest.configuration = [{"secret":{"name":"'${cr_name}'-pgbackrest-secrets"}}] |
 				.spec.backups.pgbackrest.manual.repoName = "repo1" |
 				.spec.backups.pgbackrest.manual.options = ["--type=full"] |
-				.spec.backups.pgbackrest.global.repo1-path = "/backrestrepo/postgres-operator/'$test_name${name_suffix:+-$name_suffix}'/repo1" |
+				.spec.backups.pgbackrest.global.repo1-path = "/backrestrepo/postgres-operator/'${cr_name}'/repo1" |
 				.spec.backups.pgbackrest.repos = [{"name":"repo1","s3":{"bucket":"'$BUCKET'","endpoint":"s3.amazonaws.com","region":"us-east-1"}}]
 				' $TEMP_DIR/cr.yaml
 
 			if [[ $test_name == "start-from-backup" ]]; then
 				yq eval -i '
-					.spec.dataSource.pgbackrest.configuration = [{"secret":{"name":"'$test_name'-pgbackrest-secrets"}}] |
+					.spec.dataSource.pgbackrest.configuration = [{"secret":{"name":"'${cr_name}'-pgbackrest-secrets"}}] |
 					.spec.dataSource.pgbackrest.stanza = "db" |
 					.spec.dataSource.pgbackrest.global.repo1-path = "/cluster-source/demand-backup-ppg'$PG_VER'/repo1" |
 					.spec.dataSource.pgbackrest.repo = {"name":"repo1","s3":{"bucket":"'$BUCKET'","endpoint":"s3.amazonaws.com","region":"us-east-1"}}
@@ -161,11 +162,11 @@ get_cr() {
 			;;
 		"scheduled-backup")
 			yq eval -i '
-				.spec.backups.pgbackrest.configuration = [{"secret":{"name":"'$test_name'-pgbackrest-secrets"}}] |
+				.spec.backups.pgbackrest.configuration = [{"secret":{"name":"'${cr_name}'-pgbackrest-secrets"}}] |
 				.spec.backups.pgbackrest.manual.repoName = "repo1" |
 				.spec.backups.pgbackrest.manual.options = ["--type=full"] |
-				.spec.backups.pgbackrest.global.repo1-path = "/backrestrepo/postgres-operator/'$test_name${name_suffix:+-$name_suffix}'/repo1" |
-				.spec.backups.pgbackrest.global.repo2-path = "/backrestrepo/postgres-operator/'$test_name${name_suffix:+-$name_suffix}'/repo2" |
+				.spec.backups.pgbackrest.global.repo1-path = "/backrestrepo/postgres-operator/'${cr_name}'/repo1" |
+				.spec.backups.pgbackrest.global.repo2-path = "/backrestrepo/postgres-operator/'${cr_name}'/repo2" |
 				.spec.backups.pgbackrest.repos = [{"name":"repo1","s3":{"bucket":"'$BUCKET'","endpoint":"s3.amazonaws.com","region":"us-east-1"}}] |
 				.spec.backups.pgbackrest.repos += [{"name":"repo2","gcs":{"bucket":"'$BUCKET'"}}]
 				' $TEMP_DIR/cr.yaml

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -121,8 +121,11 @@ get_client_pod() {
 }
 
 get_cr() {
-	local name_suffix=$1
-	local cr_name="${test_name}${name_suffix}"
+	local cr_name=$1
+	if [ -z ${cr_name} ]; then
+		cr_name=${test_name}
+	fi
+	local repo_path=$2
 
 	yq eval '
 		.metadata.name = "'${cr_name}'" |
@@ -147,7 +150,7 @@ get_cr() {
 				.spec.backups.pgbackrest.configuration = [{"secret":{"name":"'${cr_name}'-pgbackrest-secrets"}}] |
 				.spec.backups.pgbackrest.manual.repoName = "repo1" |
 				.spec.backups.pgbackrest.manual.options = ["--type=full"] |
-				.spec.backups.pgbackrest.global.repo1-path = "/backrestrepo/postgres-operator/'${cr_name}'/repo1" |
+				.spec.backups.pgbackrest.global.repo1-path = "/backrestrepo/postgres-operator/'${repo_path}'/repo1" |
 				.spec.backups.pgbackrest.repos = [{"name":"repo1","s3":{"bucket":"'$BUCKET'","endpoint":"s3.amazonaws.com","region":"us-east-1"}}]
 				' $TEMP_DIR/cr.yaml
 
@@ -165,8 +168,8 @@ get_cr() {
 				.spec.backups.pgbackrest.configuration = [{"secret":{"name":"'${cr_name}'-pgbackrest-secrets"}}] |
 				.spec.backups.pgbackrest.manual.repoName = "repo1" |
 				.spec.backups.pgbackrest.manual.options = ["--type=full"] |
-				.spec.backups.pgbackrest.global.repo1-path = "/backrestrepo/postgres-operator/'${cr_name}'/repo1" |
-				.spec.backups.pgbackrest.global.repo2-path = "/backrestrepo/postgres-operator/'${cr_name}'/repo2" |
+				.spec.backups.pgbackrest.global.repo1-path = "/backrestrepo/postgres-operator/'${repo_path}'/repo1" |
+				.spec.backups.pgbackrest.global.repo2-path = "/backrestrepo/postgres-operator/'${repo_path}'/repo2" |
 				.spec.backups.pgbackrest.repos = [{"name":"repo1","s3":{"bucket":"'$BUCKET'","endpoint":"s3.amazonaws.com","region":"us-east-1"}}] |
 				.spec.backups.pgbackrest.repos += [{"name":"repo2","gcs":{"bucket":"'$BUCKET'"}}]
 				' $TEMP_DIR/cr.yaml

--- a/e2e-tests/run-minikube.csv
+++ b/e2e-tests/run-minikube.csv
@@ -1,5 +1,6 @@
 custom-extensions
 demand-backup
+finalizers
 init-deploy
 one-pod
 operator-self-healing

--- a/e2e-tests/run-pr.csv
+++ b/e2e-tests/run-pr.csv
@@ -1,5 +1,6 @@
 custom-extensions
 demand-backup
+finalizers
 init-deploy
 major-upgrade
 monitoring

--- a/e2e-tests/run-release.csv
+++ b/e2e-tests/run-release.csv
@@ -1,5 +1,6 @@
 custom-extensions
 demand-backup
+finalizers
 init-deploy
 major-upgrade
 migration-backup-s3

--- a/e2e-tests/tests/demand-backup/01-create-cluster.yaml
+++ b/e2e-tests/tests/demand-backup/01-create-cluster.yaml
@@ -8,7 +8,7 @@ commands:
 
       source ../../functions
 
-      get_cr ${RANDOM} \
+      get_cr "demand-backup" ${RANDOM} \
         | yq '.spec.backups.pgbackrest.global.repo1-retention-full="2"' \
         | yq '.spec.backups.pgbackrest.global.repo1-retention-full-type="count"' \
         | kubectl -n "${NAMESPACE}" apply -f -

--- a/e2e-tests/tests/finalizers/00-assert.yaml
+++ b/e2e-tests/tests/finalizers/00-assert.yaml
@@ -1,0 +1,24 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: perconapgclusters.pgv2.percona.com
+spec:
+  group: pgv2.percona.com
+  names:
+    kind: PerconaPGCluster
+    listKind: PerconaPGClusterList
+    plural: perconapgclusters
+    singular: perconapgcluster
+  scope: Namespaced
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+metadata:
+  name: check-operator-deploy-status
+timeout: 120
+commands:
+  - script: kubectl assert exist-enhanced deployment percona-postgresql-operator -n ${OPERATOR_NS:-$NAMESPACE} --field-selector status.readyReplicas=1

--- a/e2e-tests/tests/finalizers/00-deploy-operator.yaml
+++ b/e2e-tests/tests/finalizers/00-deploy-operator.yaml
@@ -1,0 +1,13 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 10
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+      init_temp_dir # do this only in the first TestStep
+
+      deploy_operator
+      deploy_client

--- a/e2e-tests/tests/finalizers/01-assert.yaml
+++ b/e2e-tests/tests/finalizers/01-assert.yaml
@@ -1,0 +1,141 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: finalizers-repo-host
+  labels:
+    postgres-operator.crunchydata.com/cluster: finalizers
+    postgres-operator.crunchydata.com/data: pgbackrest
+    postgres-operator.crunchydata.com/pgbackrest: ''
+    postgres-operator.crunchydata.com/pgbackrest-dedicated: ''
+  ownerReferences:
+    - apiVersion: postgres-operator.crunchydata.com/v1beta1
+      kind: PostgresCluster
+      name: finalizers
+      controller: true
+      blockOwnerDeletion: true
+status:
+  observedGeneration: 1
+  replicas: 1
+  readyReplicas: 1
+  currentReplicas: 1
+  updatedReplicas: 1
+  collisionCount: 0
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: finalizers
+    postgres-operator.crunchydata.com/data: postgres
+    postgres-operator.crunchydata.com/instance-set: instance1
+  ownerReferences:
+    - apiVersion: postgres-operator.crunchydata.com/v1beta1
+      kind: PostgresCluster
+      name: finalizers
+      controller: true
+      blockOwnerDeletion: true
+status:
+  observedGeneration: 1
+  replicas: 1
+  readyReplicas: 1
+  currentReplicas: 1
+  updatedReplicas: 1
+  collisionCount: 0
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: finalizers-pgbouncer
+  labels:
+    postgres-operator.crunchydata.com/cluster: finalizers
+    postgres-operator.crunchydata.com/role: pgbouncer
+  annotations:
+    deployment.kubernetes.io/revision: '1'
+  ownerReferences:
+    - apiVersion: postgres-operator.crunchydata.com/v1beta1
+      kind: PostgresCluster
+      name: finalizers
+      controller: true
+      blockOwnerDeletion: true
+status:
+  observedGeneration: 1
+  replicas: 3
+  updatedReplicas: 3
+  readyReplicas: 3
+---
+kind: Job
+apiVersion: batch/v1
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: finalizers
+    postgres-operator.crunchydata.com/pgbackrest: ''
+    postgres-operator.crunchydata.com/pgbackrest-backup: replica-create
+    postgres-operator.crunchydata.com/pgbackrest-repo: repo1
+  annotations:
+    postgres-operator.crunchydata.com/pgbackrest-config: pgbackrest
+  ownerReferences:
+    - apiVersion: pgv2.percona.com/v2
+      kind: PerconaPGBackup
+      controller: true
+      blockOwnerDeletion: true
+status:
+  succeeded: 1
+---
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: finalizers
+  ownerReferences:
+    - apiVersion: pgv2.percona.com/v2
+      kind: PerconaPGCluster
+      name: finalizers
+      controller: true
+      blockOwnerDeletion: true
+  finalizers:
+    - postgres-operator.crunchydata.com/finalizer
+status:
+  instances:
+    - name: instance1
+      readyReplicas: 3
+      replicas: 3
+      updatedReplicas: 3
+  observedGeneration: 1
+  pgbackrest:
+    repoHost:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      ready: true
+    repos:
+      - bound: true
+        name: repo1
+        replicaCreateBackupComplete: true
+        stanzaCreated: true
+  proxy:
+    pgBouncer:
+      readyReplicas: 3
+      replicas: 3
+---
+apiVersion: pgv2.percona.com/v2
+kind: PerconaPGCluster
+metadata:
+  name: finalizers
+  finalizers:
+  - percona.com/delete-pvc
+  - percona.com/delete-ssl
+  - percona.com/stop-watchers
+status:
+  pgbouncer:
+    ready: 3
+    size: 3
+  postgres:
+    instances:
+    - name: instance1
+      ready: 3
+      size: 3
+    ready: 3
+    size: 3
+  state: ready

--- a/e2e-tests/tests/finalizers/01-create-cluster.yaml
+++ b/e2e-tests/tests/finalizers/01-create-cluster.yaml
@@ -1,0 +1,13 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 10
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      get_cr \
+        | yq eval '.metadata.finalizers += ["percona.com/delete-pvc", "percona.com/delete-ssl"]' \
+        | kubectl -n "${NAMESPACE}" apply -f -

--- a/e2e-tests/tests/finalizers/02-delete-cluster.yaml
+++ b/e2e-tests/tests/finalizers/02-delete-cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: pgv2.percona.com/v2
+  kind: PerconaPGCluster
+  name: finalizers

--- a/e2e-tests/tests/finalizers/03-assert.yaml
+++ b/e2e-tests/tests/finalizers/03-assert.yaml
@@ -1,0 +1,141 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: finalizers-2-repo-host
+  labels:
+    postgres-operator.crunchydata.com/cluster: finalizers-2
+    postgres-operator.crunchydata.com/data: pgbackrest
+    postgres-operator.crunchydata.com/pgbackrest: ''
+    postgres-operator.crunchydata.com/pgbackrest-dedicated: ''
+  ownerReferences:
+    - apiVersion: postgres-operator.crunchydata.com/v1beta1
+      kind: PostgresCluster
+      name: finalizers-2
+      controller: true
+      blockOwnerDeletion: true
+status:
+  observedGeneration: 1
+  replicas: 1
+  readyReplicas: 1
+  currentReplicas: 1
+  updatedReplicas: 1
+  collisionCount: 0
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: finalizers-2
+    postgres-operator.crunchydata.com/data: postgres
+    postgres-operator.crunchydata.com/instance-set: instance1
+  ownerReferences:
+    - apiVersion: postgres-operator.crunchydata.com/v1beta1
+      kind: PostgresCluster
+      name: finalizers-2
+      controller: true
+      blockOwnerDeletion: true
+status:
+  observedGeneration: 1
+  replicas: 1
+  readyReplicas: 1
+  currentReplicas: 1
+  updatedReplicas: 1
+  collisionCount: 0
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: finalizers-2-pgbouncer
+  labels:
+    postgres-operator.crunchydata.com/cluster: finalizers-2
+    postgres-operator.crunchydata.com/role: pgbouncer
+  annotations:
+    deployment.kubernetes.io/revision: '1'
+  ownerReferences:
+    - apiVersion: postgres-operator.crunchydata.com/v1beta1
+      kind: PostgresCluster
+      name: finalizers-2
+      controller: true
+      blockOwnerDeletion: true
+status:
+  observedGeneration: 1
+  replicas: 3
+  updatedReplicas: 3
+  readyReplicas: 3
+---
+kind: Job
+apiVersion: batch/v1
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: finalizers-2
+    postgres-operator.crunchydata.com/pgbackrest: ''
+    postgres-operator.crunchydata.com/pgbackrest-backup: replica-create
+    postgres-operator.crunchydata.com/pgbackrest-repo: repo1
+  annotations:
+    postgres-operator.crunchydata.com/pgbackrest-config: pgbackrest
+  ownerReferences:
+    - apiVersion: pgv2.percona.com/v2
+      kind: PerconaPGBackup
+      controller: true
+      blockOwnerDeletion: true
+status:
+  succeeded: 1
+---
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: finalizers-2
+  ownerReferences:
+    - apiVersion: pgv2.percona.com/v2
+      kind: PerconaPGCluster
+      name: finalizers-2
+      controller: true
+      blockOwnerDeletion: true
+  finalizers:
+    - postgres-operator.crunchydata.com/finalizer
+status:
+  instances:
+    - name: instance1
+      readyReplicas: 3
+      replicas: 3
+      updatedReplicas: 3
+  observedGeneration: 1
+  pgbackrest:
+    repoHost:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      ready: true
+    repos:
+      - bound: true
+        name: repo1
+        replicaCreateBackupComplete: true
+        stanzaCreated: true
+  proxy:
+    pgBouncer:
+      readyReplicas: 3
+      replicas: 3
+---
+apiVersion: pgv2.percona.com/v2
+kind: PerconaPGCluster
+metadata:
+  name: finalizers-2
+  finalizers:
+  - percona.com/delete-pvc
+  - percona.com/delete-ssl
+  - percona.com/stop-watchers
+status:
+  pgbouncer:
+    ready: 3
+    size: 3
+  postgres:
+    instances:
+    - name: instance1
+      ready: 3
+      size: 3
+    ready: 3
+    size: 3
+  state: ready

--- a/e2e-tests/tests/finalizers/03-create-cluster.yaml
+++ b/e2e-tests/tests/finalizers/03-create-cluster.yaml
@@ -8,6 +8,6 @@ commands:
 
       source ../../functions
 
-      get_cr "-2" \
+      get_cr "finalizers-2" \
         | yq eval '.metadata.finalizers += ["percona.com/delete-pvc", "percona.com/delete-ssl"]' \
         | kubectl -n "${NAMESPACE}" apply -f -

--- a/e2e-tests/tests/finalizers/03-create-cluster.yaml
+++ b/e2e-tests/tests/finalizers/03-create-cluster.yaml
@@ -1,0 +1,13 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 10
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      get_cr "-2" \
+        | yq eval '.metadata.finalizers += ["percona.com/delete-pvc", "percona.com/delete-ssl"]' \
+        | kubectl -n "${NAMESPACE}" apply -f -

--- a/e2e-tests/tests/finalizers/99-remove-cluster-gracefully.yaml
+++ b/e2e-tests/tests/finalizers/99-remove-cluster-gracefully.yaml
@@ -1,0 +1,20 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: pgv2.percona.com/v2
+  kind: PerconaPGCluster
+  metadata:
+    name: init-deploy
+- apiVersion: postgres-operator.crunchydata.com/v1beta1
+  kind: PostgresCluster
+  metadata:
+    name: init-deploy
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      destroy_operator
+    timeout: 60

--- a/e2e-tests/tests/pitr/01-create-cluster.yaml
+++ b/e2e-tests/tests/pitr/01-create-cluster.yaml
@@ -8,4 +8,4 @@ commands:
 
       source ../../functions
 
-      get_cr ${RANDOM}| kubectl -n "${NAMESPACE}" apply -f -
+      get_cr "pitr" ${RANDOM}| kubectl -n "${NAMESPACE}" apply -f -

--- a/e2e-tests/tests/scheduled-backup/01-create-cluster.yaml
+++ b/e2e-tests/tests/scheduled-backup/01-create-cluster.yaml
@@ -8,4 +8,4 @@ commands:
 
       source ../../functions
 
-      get_cr ${RANDOM} | kubectl -n "${NAMESPACE}" apply -f -
+      get_cr "scheduled-backup" ${RANDOM} | kubectl -n "${NAMESPACE}" apply -f -

--- a/e2e-tests/tests/start-from-backup/01-create-cluster.yaml
+++ b/e2e-tests/tests/start-from-backup/01-create-cluster.yaml
@@ -8,4 +8,4 @@ commands:
 
       source ../../functions
 
-      get_cr ${RANDOM}| kubectl -n "${NAMESPACE}" apply -f -
+      get_cr "start-from-backup" ${RANDOM}| kubectl -n "${NAMESPACE}" apply -f -

--- a/e2e-tests/tests/tablespaces/01-create-cluster.yaml
+++ b/e2e-tests/tests/tablespaces/01-create-cluster.yaml
@@ -8,7 +8,7 @@ commands:
 
       source ../../functions
 
-      get_cr ${RANDOM} \
+      get_cr "tablespaces" ${RANDOM} \
         | yq eval '
             .spec.instances[].tablespaceVolumes[0].name="myts" |
             .spec.instances[].tablespaceVolumes[0].dataVolumeClaimSpec.accessModes[0]="ReadWriteOnce" |

--- a/e2e-tests/tests/users/01-create-cluster.yaml
+++ b/e2e-tests/tests/users/01-create-cluster.yaml
@@ -8,4 +8,4 @@ commands:
 
       source ../../functions
 
-      get_cr ${RANDOM}| kubectl -n "${NAMESPACE}" apply -f -
+      get_cr "users" ${RANDOM}| kubectl -n "${NAMESPACE}" apply -f -


### PR DESCRIPTION
[![K8SPG-616](https://badgen.net/badge/JIRA/K8SPG-616/green)](https://jira.percona.com/browse/K8SPG-616) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
For some reason `percona.com/stop-watchers` finalizer runs twice and in the second run it tries to send data to a channel no one reads from and this makes operator stuck. **This is a sporadic issue.**

**Solution:**
Ensure operator is not stuck even if it tries to send to channel with no readers.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PG version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-616]: https://perconadev.atlassian.net/browse/K8SPG-616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ