### PR TITLE
K8SPG-604: fix scheduled backup

### DIFF
--- a/e2e-tests/tests/scheduled-backup/01-assert.yaml
+++ b/e2e-tests/tests/scheduled-backup/01-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 300
+timeout: 420
 ---
 kind: StatefulSet
 apiVersion: apps/v1

--- a/e2e-tests/tests/scheduled-backup/06-assert.yaml
+++ b/e2e-tests/tests/scheduled-backup/06-assert.yaml
@@ -9,9 +9,6 @@ metadata:
 spec:
   pgCluster: scheduled-backup
   repoName: repo2
-status:
-  backupType: full
-  state: Succeeded
 ---
 apiVersion: pgv2.percona.com/v2
 kind: PerconaPGBackup
@@ -34,11 +31,3 @@ spec:
 status:
   backupType: full
   state: Succeeded
----
-apiVersion: postgres-operator.crunchydata.com/v1beta1
-kind: PostgresCluster
-metadata:
-  name: scheduled-backup
-  generation: 6
-status:
-  observedGeneration: 6

--- a/e2e-tests/tests/scheduled-backup/06-assert.yaml
+++ b/e2e-tests/tests/scheduled-backup/06-assert.yaml
@@ -31,3 +31,11 @@ spec:
 status:
   backupType: full
   state: Succeeded
+---
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: scheduled-backup
+  generation: 6
+status:
+  observedGeneration: 6

--- a/e2e-tests/tests/scheduled-backup/06-assert.yaml
+++ b/e2e-tests/tests/scheduled-backup/06-assert.yaml
@@ -31,11 +31,3 @@ spec:
 status:
   backupType: full
   state: Succeeded
----
-apiVersion: postgres-operator.crunchydata.com/v1beta1
-kind: PostgresCluster
-metadata:
-  name: scheduled-backup
-  generation: 6
-status:
-  observedGeneration: 6

--- a/e2e-tests/tests/scheduled-backup/06-engage-gcs.yaml
+++ b/e2e-tests/tests/scheduled-backup/06-engage-gcs.yaml
@@ -15,7 +15,7 @@ spec:
             bucket: pg-operator-testing
           name: repo2
           schedules:
-            full: "*/1 * * * *"
+            full: "*/5 * * * *"
         - azure:
             container: pg-operator-testing
           name: repo3

--- a/e2e-tests/tests/scheduled-backup/06-engage-gcs.yaml
+++ b/e2e-tests/tests/scheduled-backup/06-engage-gcs.yaml
@@ -15,7 +15,7 @@ spec:
             bucket: pg-operator-testing
           name: repo2
           schedules:
-            full: "*/5 * * * *"
+            full: "*/1 * * * *"
         - azure:
             container: pg-operator-testing
           name: repo3

--- a/e2e-tests/tests/scheduled-backup/06-engage-gcs.yaml
+++ b/e2e-tests/tests/scheduled-backup/06-engage-gcs.yaml
@@ -15,7 +15,7 @@ spec:
             bucket: pg-operator-testing
           name: repo2
           schedules:
-            full: "*/4 * * * *"
+            full: "*/1 * * * *"
         - azure:
             container: pg-operator-testing
           name: repo3

--- a/e2e-tests/tests/scheduled-backup/06-engage-gcs.yaml
+++ b/e2e-tests/tests/scheduled-backup/06-engage-gcs.yaml
@@ -15,7 +15,7 @@ spec:
             bucket: pg-operator-testing
           name: repo2
           schedules:
-            full: "*/5 * * * *"
+            full: "*/4 * * * *"
         - azure:
             container: pg-operator-testing
           name: repo3

--- a/e2e-tests/tests/scheduled-backup/07-assert.yaml
+++ b/e2e-tests/tests/scheduled-backup/07-assert.yaml
@@ -39,4 +39,11 @@ spec:
 status:
   backupType: full
   state: Succeeded
-
+---
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: scheduled-backup
+  generation: 8
+status:
+  observedGeneration: 8

--- a/e2e-tests/tests/scheduled-backup/07-assert.yaml
+++ b/e2e-tests/tests/scheduled-backup/07-assert.yaml
@@ -39,11 +39,4 @@ spec:
 status:
   backupType: full
   state: Succeeded
----
-apiVersion: postgres-operator.crunchydata.com/v1beta1
-kind: PostgresCluster
-metadata:
-  name: scheduled-backup
-  generation: 8
-status:
-  observedGeneration: 8
+

--- a/e2e-tests/tests/scheduled-backup/07-assert.yaml
+++ b/e2e-tests/tests/scheduled-backup/07-assert.yaml
@@ -2,20 +2,6 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 timeout: 600
 ---
----
-kind: Job
-apiVersion: batch/v1
-metadata:
-  labels:
-    postgres-operator.crunchydata.com/pgbackrest-repo: repo2
-  ownerReferences:
-    - apiVersion: pgv2.percona.com/v2
-      kind: PerconaPGBackup
-      controller: true
-      blockOwnerDeletion: true
-status:
-  succeeded: 1
----
 apiVersion: pgv2.percona.com/v2
 kind: PerconaPGBackup
 metadata:
@@ -31,9 +17,6 @@ metadata:
 spec:
   pgCluster: scheduled-backup
   repoName: repo2
-status:
-  backupType: full
-  state: Succeeded
 ---
 apiVersion: pgv2.percona.com/v2
 kind: PerconaPGBackup
@@ -56,11 +39,4 @@ spec:
 status:
   backupType: full
   state: Succeeded
----
-apiVersion: postgres-operator.crunchydata.com/v1beta1
-kind: PostgresCluster
-metadata:
-  name: scheduled-backup
-  generation: 8
-status:
-  observedGeneration: 8
+

--- a/e2e-tests/tests/scheduled-backup/07-engage-azure.yaml
+++ b/e2e-tests/tests/scheduled-backup/07-engage-azure.yaml
@@ -18,4 +18,4 @@ spec:
             container: pg-operator-testing
           name: repo3
           schedules:
-            full: "*/5 * * * *"
+            full: "*/1 * * * *"

--- a/e2e-tests/tests/scheduled-backup/07-engage-azure.yaml
+++ b/e2e-tests/tests/scheduled-backup/07-engage-azure.yaml
@@ -18,4 +18,4 @@ spec:
             container: pg-operator-testing
           name: repo3
           schedules:
-            full: "*/1 * * * *"
+            full: "*/5 * * * *"

--- a/e2e-tests/tests/scheduled-backup/08-assert.yaml
+++ b/e2e-tests/tests/scheduled-backup/08-assert.yaml
@@ -15,6 +15,19 @@ metadata:
 status:
   succeeded: 1
 ---
+kind: Job
+apiVersion: batch/v1
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/pgbackrest-repo: repo2
+  ownerReferences:
+    - apiVersion: pgv2.percona.com/v2
+      kind: PerconaPGBackup
+      controller: true
+      blockOwnerDeletion: true
+status:
+  succeeded: 1
+---
 apiVersion: pgv2.percona.com/v2
 kind: PerconaPGBackup
 metadata:
@@ -22,6 +35,17 @@ metadata:
 spec:
   pgCluster: scheduled-backup
   repoName: repo3
+status:
+  backupType: full
+  state: Succeeded
+---
+apiVersion: pgv2.percona.com/v2
+kind: PerconaPGBackup
+metadata:
+  generation: 1
+spec:
+  pgCluster: scheduled-backup
+  repoName: repo2
 status:
   backupType: full
   state: Succeeded


### PR DESCRIPTION
[![K8SPG-604](https://badgen.net/badge/JIRA/K8SPG-604/green)](https://jira.percona.com/browse/K8SPG-604) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
assert-10.yaml test is failing due to too big generation.

**Cause:**
On tests 6 and 7 backup is made too long so a couple of azure/gcp backups is scheduled instead of 1 while Success status and required Generation are waited. As a result on step 10 Generation is bigger than expected because more backups were made.

**Solution:**
Check PostgresCluster Generation and Success status of Backups only on step 8 after disabling backups.


**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-604]: https://perconadev.atlassian.net/browse/K8SPG-604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ