### PR TITLE
K8SPG-631 Add cross-namespace cluster restore example

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -46,6 +46,7 @@ spec:
 #  dataSource:
 #    postgresCluster:
 #      clusterName: cluster1
+#      clusterNamespace: cluster1-namespace
 #      repoName: repo1
 #      options:
 #      - --type=time


### PR DESCRIPTION
[![K8SPG-631](https://badgen.net/badge/JIRA/K8SPG-631/green)](https://jira.percona.com/browse/K8SPG-631) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
The `dataSource.postgresCluster.clusterNamespace` CR option mentioned in K8SPG-631 ticket is usable but not present in deploy/cr.yaml

**Solution:**
Update deploy/cr.yaml to follow the documentation update

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-631]: https://perconadev.atlassian.net/browse/K8SPG-631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ