### PR TITLE
K8SPG-604: increase timeouts for major-upgrade tests

### DIFF
--- a/e2e-tests/tests/major-upgrade/01-assert.yaml
+++ b/e2e-tests/tests/major-upgrade/01-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 120
+timeout: 320
 ---
 kind: StatefulSet
 apiVersion: apps/v1

--- a/e2e-tests/tests/major-upgrade/10-assert.yaml
+++ b/e2e-tests/tests/major-upgrade/10-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 360
+timeout: 720
 ---
 apiVersion: pgv2.percona.com/v2
 kind: PerconaPGCluster

--- a/e2e-tests/tests/major-upgrade/11-assert.yaml
+++ b/e2e-tests/tests/major-upgrade/11-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 660
+timeout: 860
 ---
 kind: Job
 apiVersion: batch/v1

--- a/e2e-tests/tests/major-upgrade/12-assert.yaml
+++ b/e2e-tests/tests/major-upgrade/12-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 950
+timeout: 1060
 ---
 apiVersion: pgv2.percona.com/v2
 kind: PerconaPGRestore

--- a/e2e-tests/tests/major-upgrade/20-assert.yaml
+++ b/e2e-tests/tests/major-upgrade/20-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 360
+timeout: 720
 ---
 apiVersion: pgv2.percona.com/v2
 kind: PerconaPGCluster

--- a/e2e-tests/tests/major-upgrade/21-assert.yaml
+++ b/e2e-tests/tests/major-upgrade/21-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 660
+timeout: 820
 ---
 kind: Job
 apiVersion: batch/v1

--- a/e2e-tests/tests/major-upgrade/22-assert.yaml
+++ b/e2e-tests/tests/major-upgrade/22-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 1000
+timeout: 1060
 ---
 apiVersion: pgv2.percona.com/v2
 kind: PerconaPGRestore

--- a/e2e-tests/tests/major-upgrade/30-assert.yaml
+++ b/e2e-tests/tests/major-upgrade/30-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 360
+timeout: 720
 ---
 apiVersion: pgv2.percona.com/v2
 kind: PerconaPGCluster

--- a/e2e-tests/tests/major-upgrade/31-assert.yaml
+++ b/e2e-tests/tests/major-upgrade/31-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 660
+timeout: 860
 ---
 kind: Job
 apiVersion: batch/v1

--- a/e2e-tests/tests/major-upgrade/32-assert.yaml
+++ b/e2e-tests/tests/major-upgrade/32-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 800
+timeout: 1060
 ---
 apiVersion: pgv2.percona.com/v2
 kind: PerconaPGRestore

--- a/e2e-tests/tests/major-upgrade/40-assert.yaml
+++ b/e2e-tests/tests/major-upgrade/40-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 360
+timeout: 620
 ---
 apiVersion: pgv2.percona.com/v2
 kind: PerconaPGCluster

--- a/e2e-tests/tests/major-upgrade/41-assert.yaml
+++ b/e2e-tests/tests/major-upgrade/41-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 660
+timeout: 720
 ---
 kind: Job
 apiVersion: batch/v1

--- a/e2e-tests/tests/major-upgrade/42-assert.yaml
+++ b/e2e-tests/tests/major-upgrade/42-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 720
+timeout: 1060
 ---
 apiVersion: pgv2.percona.com/v2
 kind: PerconaPGRestore


### PR DESCRIPTION
[![K8SPG-604](https://badgen.net/badge/JIRA/K8SPG-604/green)](https://jira.percona.com/browse/K8SPG-604) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
major-update fails ok aks and eks

**Cause:**
The timeouts are not enough to start cluster

**Solution:**
Increase timeouts

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?