### PR TITLE
K8SPG-692: set `resources` & `securityConext` for patroni version check

### DIFF
--- a/percona/controller/pgcluster/controller.go
+++ b/percona/controller/pgcluster/controller.go
@@ -344,6 +344,9 @@ func (r *PGClusterReconciler) reconcilePatroniVersionCheck(ctx context.Context, 
 		return errors.Wrap(err, "failed to get patroni version check pod")
 	}
 	if k8serrors.IsNotFound(err) {
+		if len(cr.Spec.InstanceSets) == 0 {
+			return errors.New(".spec.instances is a required value") // shouldn't happen as the value is required in the crd.yaml
+		}
 		p = &corev1.Pod{
 			ObjectMeta: meta,
 			Spec: corev1.PodSpec{
@@ -359,6 +362,8 @@ func (r *PGClusterReconciler) reconcilePatroniVersionCheck(ctx context.Context, 
 						},
 					},
 				},
+				Resources:       &cr.Spec.InstanceSets[0].Resources,
+				SecurityContext: cr.Spec.InstanceSets[0].SecurityContext,
 			},
 		}
 


### PR DESCRIPTION
[![K8SPG-692](https://badgen.net/badge/JIRA/K8SPG-692/green)](https://jira.percona.com/browse/K8SPG-692) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPG-692

**DESCRIPTION**
---
In this PR, the `*-patroni-version-check` pod gets `resources` and `securityContext` from `.spec.instances[0]`. This should be fine as the pod is created and deleted before the pg pods are deployed.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-692]: https://perconadev.atlassian.net/browse/K8SPG-692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ