### PR TITLE
K8SPG-619: fix applying `backoffLimit` for backup jobs

### DIFF
--- a/e2e-tests/tests/demand-backup/01-create-cluster.yaml
+++ b/e2e-tests/tests/demand-backup/01-create-cluster.yaml
@@ -14,4 +14,6 @@ commands:
         | yq '.spec.backups.pgbackrest.global.repo1-retention-full-type="count"' \
         | yq '.spec.backups.pgbackrest.global.repo3-retention-full="2"' \
         | yq '.spec.backups.pgbackrest.global.repo3-retention-full-type="count"' \
+        | yq '.spec.backups.pgbackrest.jobs.backoffLimit=20' \
+        | yq '.spec.backups.pgbackrest.jobs.restartPolicy="OnFailure"' \
         | kubectl -n "${NAMESPACE}" apply -f -

--- a/e2e-tests/tests/demand-backup/04-assert.yaml
+++ b/e2e-tests/tests/demand-backup/04-assert.yaml
@@ -15,6 +15,70 @@ metadata:
       kind: PerconaPGBackup
       controller: true
       blockOwnerDeletion: true
+spec:
+  backoffLimit: 20
+  template:
+    metadata:
+      annotations:
+        postgres-operator.crunchydata.com/pgbackrest-backup: demand-backup-full-s3
+    spec:
+      containers:
+      - command:
+        - /opt/crunchy/bin/pgbackrest
+        imagePullPolicy: Always
+        name: pgbackrest
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/pgbackrest/conf.d
+          name: pgbackrest-config
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: false
+      restartPolicy: OnFailure
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccount: demand-backup-pgbackrest
+      serviceAccountName: demand-backup-pgbackrest
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: pgbackrest-config
+        projected:
+          defaultMode: 420
+          sources:
+          - secret:
+              name: demand-backup-pgbackrest-secrets
+          - configMap:
+              items:
+              - key: pgbackrest_repo.conf
+                path: pgbackrest_repo.conf
+              - key: config-hash
+                path: config-hash
+              - key: pgbackrest-server.conf
+                path: ~postgres-operator_server.conf
+              name: demand-backup-pgbackrest-config
+          - secret:
+              items:
+              - key: pgbackrest.ca-roots
+                path: ~postgres-operator/tls-ca.crt
+              - key: pgbackrest-client.crt
+                path: ~postgres-operator/client-tls.crt
+              - key: pgbackrest-client.key
+                mode: 384
+                path: ~postgres-operator/client-tls.key
+              name: demand-backup-pgbackrest
 status:
   succeeded: 1
 ---

--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -866,7 +866,7 @@ func generateBackupJobSpecIntent(ctx context.Context, postgresCluster *v1beta1.P
 			jobSpec.Template.Spec.RestartPolicy = postgresCluster.Spec.Backups.PGBackRest.Jobs.RestartPolicy
 		}
 		// K8SPG-619
-		if jobSpec.BackoffLimit != nil {
+		if postgresCluster.Spec.Backups.PGBackRest.Jobs.BackoffLimit != nil {
 			jobSpec.BackoffLimit = postgresCluster.Spec.Backups.PGBackRest.Jobs.BackoffLimit
 		}
 	}


### PR DESCRIPTION
[![K8SPG-619](https://badgen.net/badge/JIRA/K8SPG-619/green)](https://jira.percona.com/browse/K8SPG-619) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPG-619

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-619]: https://perconadev.atlassian.net/browse/K8SPG-619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ