### PR TITLE
K8SPG-713: handle errors on pgcluster deletion

### DIFF
--- a/internal/controller/postgrescluster/delete.go
+++ b/internal/controller/postgrescluster/delete.go
@@ -100,5 +100,10 @@ func (r *Reconciler) handleDelete(
 		client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})))
 
 	// The caller should wait for further events or requeue upon error.
-	return &reconcile.Result{}, err
+
+	// K8SPG-713: For some reason we get a "not found" error when we try to remove finalizer.
+	//            This is unexpected because finalizers are designed to prevent objects from being deleted
+	//            until all finalizers have been deleted.
+
+	return &reconcile.Result{}, client.IgnoreNotFound(err)
 }

--- a/percona/controller/pgcluster/controller.go
+++ b/percona/controller/pgcluster/controller.go
@@ -312,6 +312,9 @@ func (r *PGClusterReconciler) Reconcile(ctx context.Context, request reconcile.R
 	}
 
 	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(postgresCluster), postgresCluster); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+		}
 		return ctrl.Result{}, errors.Wrap(err, "get PostgresCluster")
 	}
 
@@ -371,6 +374,9 @@ func (r *PGClusterReconciler) reconcilePatroniVersionCheck(ctx context.Context, 
 			},
 		}
 
+		if err := controllerutil.SetControllerReference(cr, p, r.Client.Scheme()); err != nil {
+			return errors.Wrap(err, "set controller reference")
+		}
 		if err := r.Client.Create(ctx, p); err != nil {
 			return errors.Wrap(err, "failed to create pod to check patroni version")
 		}

--- a/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
+++ b/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
@@ -246,8 +246,9 @@ func (cr *PerconaPGCluster) ToCrunchy(ctx context.Context, postgresCluster *crun
 	if postgresCluster == nil {
 		postgresCluster = &crunchyv1beta1.PostgresCluster{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      cr.Name,
-				Namespace: cr.Namespace,
+				Name:       cr.Name,
+				Namespace:  cr.Namespace,
+				Finalizers: []string{naming.Finalizer},
 			},
 		}
 	}


### PR DESCRIPTION
[![K8SPG-713](https://badgen.net/badge/JIRA/K8SPG-713/green)](https://jira.percona.com/browse/K8SPG-713) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPG-713

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-713]: https://perconadev.atlassian.net/browse/K8SPG-713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ