### PR TITLE
K8SPG-714: fix panic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Basic tests
         run: make check
       - name: envtest
-        run: ENVTEST_K8S_VERSION=1.28 make check-envtest
+        run: ENVTEST_K8S_VERSION=1.32 make check-envtest

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -2993,7 +2993,7 @@ func TestObserveRestoreEnv(t *testing.T) {
 					},
 				},
 			},
-            // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
+			// K8SPG-714: ENVTEST_K8S_VERSION=1.32
 			Status: batchv1.JobStatus{
 				StartTime: ptr.To(metav1.NewTime(time.Now().Add(-time.Minute))),
 			},
@@ -3001,7 +3001,7 @@ func TestObserveRestoreEnv(t *testing.T) {
 
 		if completed != nil {
 			if *completed {
-                // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
+				// K8SPG-714: ENVTEST_K8S_VERSION=1.32
 				restoreJob.Status.CompletionTime = ptr.To(metav1.Now())
 				restoreJob.Status.Succeeded = 1
 				restoreJob.Status.Conditions = append(restoreJob.Status.Conditions, batchv1.JobCondition{
@@ -3026,7 +3026,7 @@ func TestObserveRestoreEnv(t *testing.T) {
 			}
 		} else if failed != nil {
 			if *failed {
-                // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
+				// K8SPG-714: ENVTEST_K8S_VERSION=1.32
 				restoreJob.Status.Conditions = append(restoreJob.Status.Conditions, batchv1.JobCondition{
 					Type:    batchv1.JobFailureTarget,
 					Status:  corev1.ConditionTrue,

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -2992,10 +2992,21 @@ func TestObserveRestoreEnv(t *testing.T) {
 					},
 				},
 			},
+			Status: batchv1.JobStatus{
+				StartTime: ptr.To(metav1.NewTime(time.Now().Add(-time.Minute))),
+			},
 		}
 
 		if completed != nil {
 			if *completed {
+				restoreJob.Status.CompletionTime = ptr.To(metav1.Now())
+				restoreJob.Status.Succeeded = 1
+				restoreJob.Status.Conditions = append(restoreJob.Status.Conditions, batchv1.JobCondition{
+					Type:    batchv1.JobSuccessCriteriaMet,
+					Status:  corev1.ConditionTrue,
+					Reason:  "test",
+					Message: "test",
+				})
 				restoreJob.Status.Conditions = append(restoreJob.Status.Conditions, batchv1.JobCondition{
 					Type:    batchv1.JobComplete,
 					Status:  corev1.ConditionTrue,
@@ -3012,6 +3023,12 @@ func TestObserveRestoreEnv(t *testing.T) {
 			}
 		} else if failed != nil {
 			if *failed {
+				restoreJob.Status.Conditions = append(restoreJob.Status.Conditions, batchv1.JobCondition{
+					Type:    batchv1.JobFailureTarget,
+					Status:  corev1.ConditionTrue,
+					Reason:  "test",
+					Message: "test",
+				})
 				restoreJob.Status.Conditions = append(restoreJob.Status.Conditions, batchv1.JobCondition{
 					Type:    batchv1.JobFailed,
 					Status:  corev1.ConditionTrue,

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/utils/ptr"
+	"k8s.io/utils/ptr" // K8SPG-714
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -2993,6 +2993,7 @@ func TestObserveRestoreEnv(t *testing.T) {
 					},
 				},
 			},
+            // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
 			Status: batchv1.JobStatus{
 				StartTime: ptr.To(metav1.NewTime(time.Now().Add(-time.Minute))),
 			},
@@ -3000,6 +3001,7 @@ func TestObserveRestoreEnv(t *testing.T) {
 
 		if completed != nil {
 			if *completed {
+                // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
 				restoreJob.Status.CompletionTime = ptr.To(metav1.Now())
 				restoreJob.Status.Succeeded = 1
 				restoreJob.Status.Conditions = append(restoreJob.Status.Conditions, batchv1.JobCondition{
@@ -3024,6 +3026,7 @@ func TestObserveRestoreEnv(t *testing.T) {
 			}
 		} else if failed != nil {
 			if *failed {
+                // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
 				restoreJob.Status.Conditions = append(restoreJob.Status.Conditions, batchv1.JobCondition{
 					Type:    batchv1.JobFailureTarget,
 					Status:  corev1.ConditionTrue,

--- a/internal/controller/postgrescluster/snapshots_test.go
+++ b/internal/controller/postgrescluster/snapshots_test.go
@@ -501,11 +501,11 @@ func TestReconcileDedicatedSnapshotVolume(t *testing.T) {
 
 		currentTime := metav1.Now()
 		backupJob.Status = batchv1.JobStatus{
-			StartTime:      ptr.To(metav1.NewTime(currentTime.Add(-time.Minute))), // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
+			StartTime:      ptr.To(metav1.NewTime(currentTime.Add(-time.Minute))), // K8SPG-714: ENVTEST_K8S_VERSION=1.32
 			Succeeded:      1,
 			CompletionTime: &currentTime,
 		}
-        // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
+		// K8SPG-714: ENVTEST_K8S_VERSION=1.32
 		backupJob.Status.Conditions = append(backupJob.Status.Conditions, batchv1.JobCondition{
 			Type:    batchv1.JobSuccessCriteriaMet,
 			Status:  corev1.ConditionTrue,
@@ -570,10 +570,10 @@ func TestReconcileDedicatedSnapshotVolume(t *testing.T) {
 
 		backupJob.Status = batchv1.JobStatus{
 			Succeeded:      1,
-			StartTime:      ptr.To(metav1.NewTime(earlierTime.Add(-time.Minute))), // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
+			StartTime:      ptr.To(metav1.NewTime(earlierTime.Add(-time.Minute))), // K8SPG-714: ENVTEST_K8S_VERSION=1.32
 			CompletionTime: &earlierTime,
 		}
-        // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
+		// K8SPG-714: ENVTEST_K8S_VERSION=1.32
 		backupJob.Status.Conditions = append(backupJob.Status.Conditions, batchv1.JobCondition{
 			Type:    batchv1.JobSuccessCriteriaMet,
 			Status:  corev1.ConditionTrue,
@@ -602,8 +602,8 @@ func TestReconcileDedicatedSnapshotVolume(t *testing.T) {
 		restoreJob.Status = batchv1.JobStatus{
 			Succeeded:      1,
 			CompletionTime: &currentTime,
-            // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
-			StartTime:      ptr.To(metav1.NewTime(currentTime.Add(-time.Minute))),
+			// K8SPG-714: ENVTEST_K8S_VERSION=1.32
+			StartTime: ptr.To(metav1.NewTime(currentTime.Add(-time.Minute))),
 			Conditions: []batchv1.JobCondition{
 				{
 					Type:    batchv1.JobSuccessCriteriaMet,
@@ -674,9 +674,9 @@ func TestReconcileDedicatedSnapshotVolume(t *testing.T) {
 		backupJob.Status = batchv1.JobStatus{
 			Succeeded:      1,
 			CompletionTime: &earlierTime,
-			StartTime:      ptr.To(metav1.NewTime(earlierTime.Add(-time.Minute))), // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
+			StartTime:      ptr.To(metav1.NewTime(earlierTime.Add(-time.Minute))), // K8SPG-714: ENVTEST_K8S_VERSION=1.32
 		}
-        // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
+		// K8SPG-714: ENVTEST_K8S_VERSION=1.32
 		backupJob.Status.Conditions = append(backupJob.Status.Conditions, batchv1.JobCondition{
 			Type:    batchv1.JobSuccessCriteriaMet,
 			Status:  corev1.ConditionTrue,
@@ -706,9 +706,9 @@ func TestReconcileDedicatedSnapshotVolume(t *testing.T) {
 			Succeeded:      0,
 			Failed:         1,
 			CompletionTime: &currentTime,
-			StartTime:      ptr.To(metav1.NewTime(currentTime.Add(-time.Minute))), // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
+			StartTime:      ptr.To(metav1.NewTime(currentTime.Add(-time.Minute))), // K8SPG-714: ENVTEST_K8S_VERSION=1.32
 		}
-        // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
+		// K8SPG-714: ENVTEST_K8S_VERSION=1.32
 		restoreJob.Status.Conditions = append(backupJob.Status.Conditions, batchv1.JobCondition{
 			Type:    batchv1.JobSuccessCriteriaMet,
 			Status:  corev1.ConditionTrue,
@@ -988,8 +988,8 @@ func TestGetLatestCompleteBackupJob(t *testing.T) {
 		job1.Status = batchv1.JobStatus{
 			Succeeded:      1,
 			CompletionTime: &currentTime,
-            // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
-			StartTime:      ptr.To(metav1.NewTime(currentTime.Add(-time.Minute))),
+			// K8SPG-714: ENVTEST_K8S_VERSION=1.32
+			StartTime: ptr.To(metav1.NewTime(currentTime.Add(-time.Minute))),
 			Conditions: []batchv1.JobCondition{
 				{
 					Type:    batchv1.JobSuccessCriteriaMet,
@@ -1038,8 +1038,8 @@ func TestGetLatestCompleteBackupJob(t *testing.T) {
 		job1.Status = batchv1.JobStatus{
 			Succeeded:      1,
 			CompletionTime: &currentTime,
-            // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
-			StartTime:      ptr.To(metav1.NewTime(currentTime.Add(-time.Minute))),
+			// K8SPG-714: ENVTEST_K8S_VERSION=1.32
+			StartTime: ptr.To(metav1.NewTime(currentTime.Add(-time.Minute))),
 			Conditions: []batchv1.JobCondition{
 				{
 					Type:    batchv1.JobSuccessCriteriaMet,
@@ -1065,8 +1065,8 @@ func TestGetLatestCompleteBackupJob(t *testing.T) {
 		job2.Status = batchv1.JobStatus{
 			Succeeded:      1,
 			CompletionTime: &earlierTime,
-            // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
-			StartTime:      ptr.To(metav1.NewTime(earlierTime.Add(-time.Minute))),
+			// K8SPG-714: ENVTEST_K8S_VERSION=1.32
+			StartTime: ptr.To(metav1.NewTime(earlierTime.Add(-time.Minute))),
 			Conditions: []batchv1.JobCondition{
 				{
 					Type:    batchv1.JobSuccessCriteriaMet,

--- a/internal/controller/postgrescluster/snapshots_test.go
+++ b/internal/controller/postgrescluster/snapshots_test.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
-	"k8s.io/utils/ptr"
+	"k8s.io/utils/ptr" // K8SPG-714
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/percona/percona-postgresql-operator/internal/controller/runtime"
@@ -501,10 +501,11 @@ func TestReconcileDedicatedSnapshotVolume(t *testing.T) {
 
 		currentTime := metav1.Now()
 		backupJob.Status = batchv1.JobStatus{
-			StartTime:      ptr.To(metav1.NewTime(currentTime.Add(-time.Minute))),
+			StartTime:      ptr.To(metav1.NewTime(currentTime.Add(-time.Minute))), // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
 			Succeeded:      1,
 			CompletionTime: &currentTime,
 		}
+        // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
 		backupJob.Status.Conditions = append(backupJob.Status.Conditions, batchv1.JobCondition{
 			Type:    batchv1.JobSuccessCriteriaMet,
 			Status:  corev1.ConditionTrue,
@@ -569,9 +570,10 @@ func TestReconcileDedicatedSnapshotVolume(t *testing.T) {
 
 		backupJob.Status = batchv1.JobStatus{
 			Succeeded:      1,
-			StartTime:      ptr.To(metav1.NewTime(earlierTime.Add(-time.Minute))),
+			StartTime:      ptr.To(metav1.NewTime(earlierTime.Add(-time.Minute))), // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
 			CompletionTime: &earlierTime,
 		}
+        // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
 		backupJob.Status.Conditions = append(backupJob.Status.Conditions, batchv1.JobCondition{
 			Type:    batchv1.JobSuccessCriteriaMet,
 			Status:  corev1.ConditionTrue,
@@ -600,6 +602,7 @@ func TestReconcileDedicatedSnapshotVolume(t *testing.T) {
 		restoreJob.Status = batchv1.JobStatus{
 			Succeeded:      1,
 			CompletionTime: &currentTime,
+            // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
 			StartTime:      ptr.To(metav1.NewTime(currentTime.Add(-time.Minute))),
 			Conditions: []batchv1.JobCondition{
 				{
@@ -671,8 +674,9 @@ func TestReconcileDedicatedSnapshotVolume(t *testing.T) {
 		backupJob.Status = batchv1.JobStatus{
 			Succeeded:      1,
 			CompletionTime: &earlierTime,
-			StartTime:      ptr.To(metav1.NewTime(earlierTime.Add(-time.Minute))),
+			StartTime:      ptr.To(metav1.NewTime(earlierTime.Add(-time.Minute))), // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
 		}
+        // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
 		backupJob.Status.Conditions = append(backupJob.Status.Conditions, batchv1.JobCondition{
 			Type:    batchv1.JobSuccessCriteriaMet,
 			Status:  corev1.ConditionTrue,
@@ -702,8 +706,9 @@ func TestReconcileDedicatedSnapshotVolume(t *testing.T) {
 			Succeeded:      0,
 			Failed:         1,
 			CompletionTime: &currentTime,
-			StartTime:      ptr.To(metav1.NewTime(currentTime.Add(-time.Minute))),
+			StartTime:      ptr.To(metav1.NewTime(currentTime.Add(-time.Minute))), // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
 		}
+        // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
 		restoreJob.Status.Conditions = append(backupJob.Status.Conditions, batchv1.JobCondition{
 			Type:    batchv1.JobSuccessCriteriaMet,
 			Status:  corev1.ConditionTrue,
@@ -983,6 +988,7 @@ func TestGetLatestCompleteBackupJob(t *testing.T) {
 		job1.Status = batchv1.JobStatus{
 			Succeeded:      1,
 			CompletionTime: &currentTime,
+            // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
 			StartTime:      ptr.To(metav1.NewTime(currentTime.Add(-time.Minute))),
 			Conditions: []batchv1.JobCondition{
 				{
@@ -1032,6 +1038,7 @@ func TestGetLatestCompleteBackupJob(t *testing.T) {
 		job1.Status = batchv1.JobStatus{
 			Succeeded:      1,
 			CompletionTime: &currentTime,
+            // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
 			StartTime:      ptr.To(metav1.NewTime(currentTime.Add(-time.Minute))),
 			Conditions: []batchv1.JobCondition{
 				{
@@ -1058,6 +1065,7 @@ func TestGetLatestCompleteBackupJob(t *testing.T) {
 		job2.Status = batchv1.JobStatus{
 			Succeeded:      1,
 			CompletionTime: &earlierTime,
+            // K8SPG-714: ENVTEST_K8S_VERSION=1.32 
 			StartTime:      ptr.To(metav1.NewTime(earlierTime.Add(-time.Minute))),
 			Conditions: []batchv1.JobCondition{
 				{

--- a/internal/controller/postgrescluster/snapshots_test.go
+++ b/internal/controller/postgrescluster/snapshots_test.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/percona/percona-postgresql-operator/internal/controller/runtime"
@@ -500,9 +501,22 @@ func TestReconcileDedicatedSnapshotVolume(t *testing.T) {
 
 		currentTime := metav1.Now()
 		backupJob.Status = batchv1.JobStatus{
+			StartTime:      ptr.To(metav1.NewTime(currentTime.Add(-time.Minute))),
 			Succeeded:      1,
 			CompletionTime: &currentTime,
 		}
+		backupJob.Status.Conditions = append(backupJob.Status.Conditions, batchv1.JobCondition{
+			Type:    batchv1.JobSuccessCriteriaMet,
+			Status:  corev1.ConditionTrue,
+			Reason:  "test",
+			Message: "test",
+		})
+		backupJob.Status.Conditions = append(backupJob.Status.Conditions, batchv1.JobCondition{
+			Type:    batchv1.JobComplete,
+			Status:  corev1.ConditionTrue,
+			Reason:  "test",
+			Message: "test",
+		})
 		err = r.Client.Status().Update(ctx, backupJob)
 		assert.NilError(t, err)
 
@@ -555,8 +569,21 @@ func TestReconcileDedicatedSnapshotVolume(t *testing.T) {
 
 		backupJob.Status = batchv1.JobStatus{
 			Succeeded:      1,
+			StartTime:      ptr.To(metav1.NewTime(earlierTime.Add(-time.Minute))),
 			CompletionTime: &earlierTime,
 		}
+		backupJob.Status.Conditions = append(backupJob.Status.Conditions, batchv1.JobCondition{
+			Type:    batchv1.JobSuccessCriteriaMet,
+			Status:  corev1.ConditionTrue,
+			Reason:  "test",
+			Message: "test",
+		})
+		backupJob.Status.Conditions = append(backupJob.Status.Conditions, batchv1.JobCondition{
+			Type:    batchv1.JobComplete,
+			Status:  corev1.ConditionTrue,
+			Reason:  "test",
+			Message: "test",
+		})
 		err = r.Client.Status().Update(ctx, backupJob)
 		assert.NilError(t, err)
 
@@ -573,6 +600,21 @@ func TestReconcileDedicatedSnapshotVolume(t *testing.T) {
 		restoreJob.Status = batchv1.JobStatus{
 			Succeeded:      1,
 			CompletionTime: &currentTime,
+			StartTime:      ptr.To(metav1.NewTime(currentTime.Add(-time.Minute))),
+			Conditions: []batchv1.JobCondition{
+				{
+					Type:    batchv1.JobSuccessCriteriaMet,
+					Status:  corev1.ConditionTrue,
+					Reason:  "test",
+					Message: "test",
+				},
+				{
+					Type:    batchv1.JobComplete,
+					Status:  corev1.ConditionTrue,
+					Reason:  "test",
+					Message: "test",
+				},
+			},
 		}
 		err = r.Client.Status().Update(ctx, restoreJob)
 		assert.NilError(t, err)
@@ -629,7 +671,20 @@ func TestReconcileDedicatedSnapshotVolume(t *testing.T) {
 		backupJob.Status = batchv1.JobStatus{
 			Succeeded:      1,
 			CompletionTime: &earlierTime,
+			StartTime:      ptr.To(metav1.NewTime(earlierTime.Add(-time.Minute))),
 		}
+		backupJob.Status.Conditions = append(backupJob.Status.Conditions, batchv1.JobCondition{
+			Type:    batchv1.JobSuccessCriteriaMet,
+			Status:  corev1.ConditionTrue,
+			Reason:  "test",
+			Message: "test",
+		})
+		backupJob.Status.Conditions = append(backupJob.Status.Conditions, batchv1.JobCondition{
+			Type:    batchv1.JobComplete,
+			Status:  corev1.ConditionTrue,
+			Reason:  "test",
+			Message: "test",
+		})
 		err = r.Client.Status().Update(ctx, backupJob)
 		assert.NilError(t, err)
 
@@ -647,7 +702,20 @@ func TestReconcileDedicatedSnapshotVolume(t *testing.T) {
 			Succeeded:      0,
 			Failed:         1,
 			CompletionTime: &currentTime,
+			StartTime:      ptr.To(metav1.NewTime(currentTime.Add(-time.Minute))),
 		}
+		restoreJob.Status.Conditions = append(backupJob.Status.Conditions, batchv1.JobCondition{
+			Type:    batchv1.JobSuccessCriteriaMet,
+			Status:  corev1.ConditionTrue,
+			Reason:  "test",
+			Message: "test",
+		})
+		restoreJob.Status.Conditions = append(backupJob.Status.Conditions, batchv1.JobCondition{
+			Type:    batchv1.JobComplete,
+			Status:  corev1.ConditionTrue,
+			Reason:  "test",
+			Message: "test",
+		})
 		err = r.Client.Status().Update(ctx, restoreJob)
 		assert.NilError(t, err)
 
@@ -915,6 +983,21 @@ func TestGetLatestCompleteBackupJob(t *testing.T) {
 		job1.Status = batchv1.JobStatus{
 			Succeeded:      1,
 			CompletionTime: &currentTime,
+			StartTime:      ptr.To(metav1.NewTime(currentTime.Add(-time.Minute))),
+			Conditions: []batchv1.JobCondition{
+				{
+					Type:    batchv1.JobSuccessCriteriaMet,
+					Status:  corev1.ConditionTrue,
+					Reason:  "test",
+					Message: "test",
+				},
+				{
+					Type:    batchv1.JobComplete,
+					Status:  corev1.ConditionTrue,
+					Reason:  "test",
+					Message: "test",
+				},
+			},
 		}
 		err = r.Client.Status().Update(ctx, job1)
 		assert.NilError(t, err)
@@ -949,6 +1032,21 @@ func TestGetLatestCompleteBackupJob(t *testing.T) {
 		job1.Status = batchv1.JobStatus{
 			Succeeded:      1,
 			CompletionTime: &currentTime,
+			StartTime:      ptr.To(metav1.NewTime(currentTime.Add(-time.Minute))),
+			Conditions: []batchv1.JobCondition{
+				{
+					Type:    batchv1.JobSuccessCriteriaMet,
+					Status:  corev1.ConditionTrue,
+					Reason:  "test",
+					Message: "test",
+				},
+				{
+					Type:    batchv1.JobComplete,
+					Status:  corev1.ConditionTrue,
+					Reason:  "test",
+					Message: "test",
+				},
+			},
 		}
 		err = r.Client.Status().Update(ctx, job1)
 		assert.NilError(t, err)
@@ -960,6 +1058,21 @@ func TestGetLatestCompleteBackupJob(t *testing.T) {
 		job2.Status = batchv1.JobStatus{
 			Succeeded:      1,
 			CompletionTime: &earlierTime,
+			StartTime:      ptr.To(metav1.NewTime(earlierTime.Add(-time.Minute))),
+			Conditions: []batchv1.JobCondition{
+				{
+					Type:    batchv1.JobSuccessCriteriaMet,
+					Status:  corev1.ConditionTrue,
+					Reason:  "test",
+					Message: "test",
+				},
+				{
+					Type:    batchv1.JobComplete,
+					Status:  corev1.ConditionTrue,
+					Reason:  "test",
+					Message: "test",
+				},
+			},
 		}
 		err = r.Client.Status().Update(ctx, job2)
 		assert.NilError(t, err)

--- a/percona/controller/pgbackup/controller.go
+++ b/percona/controller/pgbackup/controller.go
@@ -239,7 +239,7 @@ func (r *PGBackupReconciler) Reconcile(ctx context.Context, request reconcile.Re
 
 		// We need to perform the same steps as in the delete-backup finalizer once the backup has finished or failed.
 		// After that, the finalizer is no longer needed, that's why the RunFinalizer function is used here.
-		done, err := controller.RunFinalizer(ctx, r.Client, pgBackup, pNaming.FinalizerDeleteBackup, deleteBackupFinalizer(r.Client, pgCluster, pgBackup))
+		done, err := controller.RunFinalizer(ctx, r.Client, pgBackup, pNaming.FinalizerDeleteBackup, deleteBackupFinalizer(r.Client, pgCluster))
 		if err != nil {
 			return reconcile.Result{}, errors.Wrap(err, "failed to run delete-backup finalizer")
 		}
@@ -322,7 +322,7 @@ func ensureFinalizers(ctx context.Context, cl client.Client, pgBackup *v2.Percon
 	return nil
 }
 
-func deleteBackupFinalizer(c client.Client, pg *v2.PerconaPGCluster, pgBackup *v2.PerconaPGBackup) func(ctx context.Context, pgBackup *v2.PerconaPGBackup) error {
+func deleteBackupFinalizer(c client.Client, pg *v2.PerconaPGCluster) func(ctx context.Context, pgBackup *v2.PerconaPGBackup) error {
 	return func(ctx context.Context, pgBackup *v2.PerconaPGBackup) error {
 		if pg == nil {
 			return nil
@@ -357,7 +357,7 @@ func runFinalizers(ctx context.Context, c client.Client, pgBackup *v2.PerconaPGB
 	}
 
 	finalizers := map[string]controller.FinalizerFunc[*v2.PerconaPGBackup]{
-		pNaming.FinalizerDeleteBackup: deleteBackupFinalizer(c, pg, pgBackup),
+		pNaming.FinalizerDeleteBackup: deleteBackupFinalizer(c, pg),
 	}
 
 	finished := true

--- a/percona/controller/pgbackup/controller.go
+++ b/percona/controller/pgbackup/controller.go
@@ -239,7 +239,7 @@ func (r *PGBackupReconciler) Reconcile(ctx context.Context, request reconcile.Re
 
 		// We need to perform the same steps as in the delete-backup finalizer once the backup has finished or failed.
 		// After that, the finalizer is no longer needed, that's why the RunFinalizer function is used here.
-		done, err := controller.RunFinalizer(ctx, r.Client, pgBackup, pNaming.FinalizerDeleteBackup, deleteBackupFinalizer(ctx, r.Client, pgCluster, pgBackup))
+		done, err := controller.RunFinalizer(ctx, r.Client, pgBackup, pNaming.FinalizerDeleteBackup, deleteBackupFinalizer(r.Client, pgCluster, pgBackup))
 		if err != nil {
 			return reconcile.Result{}, errors.Wrap(err, "failed to run delete-backup finalizer")
 		}
@@ -322,7 +322,7 @@ func ensureFinalizers(ctx context.Context, cl client.Client, pgBackup *v2.Percon
 	return nil
 }
 
-func deleteBackupFinalizer(ctx context.Context, c client.Client, pg *v2.PerconaPGCluster, pgBackup *v2.PerconaPGBackup) func(ctx context.Context, pgBackup *v2.PerconaPGBackup) error {
+func deleteBackupFinalizer(c client.Client, pg *v2.PerconaPGCluster, pgBackup *v2.PerconaPGBackup) func(ctx context.Context, pgBackup *v2.PerconaPGBackup) error {
 	return func(ctx context.Context, pgBackup *v2.PerconaPGBackup) error {
 		if pg == nil {
 			return nil
@@ -357,7 +357,7 @@ func runFinalizers(ctx context.Context, c client.Client, pgBackup *v2.PerconaPGB
 	}
 
 	finalizers := map[string]controller.FinalizerFunc[*v2.PerconaPGBackup]{
-		pNaming.FinalizerDeleteBackup: deleteBackupFinalizer(ctx, c, pg, pgBackup),
+		pNaming.FinalizerDeleteBackup: deleteBackupFinalizer(c, pg, pgBackup),
 	}
 
 	finished := true

--- a/percona/controller/pgbackup/controller.go
+++ b/percona/controller/pgbackup/controller.go
@@ -228,11 +228,22 @@ func (r *PGBackupReconciler) Reconcile(ctx context.Context, request reconcile.Re
 			log.Info("Waiting for backup to complete")
 			return reconcile.Result{RequeueAfter: time.Second * 5}, nil
 		}
-		finished, err := runFinalizers(ctx, r.Client, pgBackup)
-		if err != nil {
-			return reconcile.Result{}, errors.Wrap(err, "failed to run finalizers")
+
+		pgCluster := &v2.PerconaPGCluster{}
+		if err := r.Client.Get(ctx, types.NamespacedName{Name: pgBackup.Spec.PGCluster, Namespace: request.Namespace}, pgCluster); err != nil {
+			if !k8serrors.IsNotFound(err) {
+				return reconcile.Result{}, errors.Wrap(err, "get PostgresCluster")
+			}
+			pgCluster = nil
 		}
-		if !finished {
+
+		// We need to perform the same steps as in the delete-backup finalizer once the backup has finished or failed.
+		// After that, the finalizer is no longer needed, that's why the RunFinalizer function is used here.
+		done, err := controller.RunFinalizer(ctx, r.Client, pgBackup, pNaming.FinalizerDeleteBackup, deleteBackupFinalizer(ctx, r.Client, pgCluster, pgBackup))
+		if err != nil {
+			return reconcile.Result{}, errors.Wrap(err, "failed to run delete-backup finalizer")
+		}
+		if !done {
 			log.Info("Waiting for crunchy reconciler to finish")
 			return reconcile.Result{RequeueAfter: time.Second * 5}, nil
 		}
@@ -311,6 +322,30 @@ func ensureFinalizers(ctx context.Context, cl client.Client, pgBackup *v2.Percon
 	return nil
 }
 
+func deleteBackupFinalizer(ctx context.Context, c client.Client, pg *v2.PerconaPGCluster, pgBackup *v2.PerconaPGBackup) func(ctx context.Context, pgBackup *v2.PerconaPGBackup) error {
+	return func(ctx context.Context, pgBackup *v2.PerconaPGBackup) error {
+		if pg == nil {
+			return nil
+		}
+
+		job := new(batchv1.Job)
+		err := c.Get(ctx, types.NamespacedName{Name: pgBackup.Status.JobName, Namespace: pgBackup.Namespace}, job)
+		if client.IgnoreNotFound(err) != nil {
+			return errors.Wrap(err, "get backup job")
+		}
+
+		rr, err := finishBackup(ctx, c, pgBackup, job)
+		if err != nil {
+			return errors.Wrap(err, "failed to finish backup")
+		}
+
+		if rr != nil && rr.RequeueAfter != 0 {
+			return controller.ErrFinalizerPending
+		}
+		return nil
+	}
+}
+
 func runFinalizers(ctx context.Context, c client.Client, pgBackup *v2.PerconaPGBackup) (bool, error) {
 	pg := new(v2.PerconaPGCluster)
 	if err := c.Get(ctx, types.NamespacedName{Name: pgBackup.Spec.PGCluster, Namespace: pgBackup.Namespace}, pg); err != nil {
@@ -322,25 +357,7 @@ func runFinalizers(ctx context.Context, c client.Client, pgBackup *v2.PerconaPGB
 	}
 
 	finalizers := map[string]controller.FinalizerFunc[*v2.PerconaPGBackup]{
-		pNaming.FinalizerDeleteBackup: func(ctx context.Context, pgBackup *v2.PerconaPGBackup) error {
-			if pg == nil {
-				return nil
-			}
-			job := new(batchv1.Job)
-			err := c.Get(ctx, types.NamespacedName{Name: pgBackup.Status.JobName, Namespace: pgBackup.Namespace}, job)
-			if client.IgnoreNotFound(err) != nil {
-				return errors.Wrap(err, "get backup job")
-			}
-			rr, err := finishBackup(ctx, c, pgBackup, job)
-			if err != nil {
-				return errors.Wrap(err, "failed to finish backup")
-			}
-
-			if rr != nil && rr.RequeueAfter != 0 {
-				return controller.ErrKeepFinalizer
-			}
-			return nil
-		},
+		pNaming.FinalizerDeleteBackup: deleteBackupFinalizer(ctx, c, pg, pgBackup),
 	}
 
 	finished := true

--- a/percona/controller/pgbackup/controller.go
+++ b/percona/controller/pgbackup/controller.go
@@ -85,8 +85,10 @@ func (r *PGBackupReconciler) Reconcile(ctx context.Context, request reconcile.Re
 		return reconcile.Result{RequeueAfter: time.Second * 5}, nil
 	}
 
-	if err := ensureFinalizers(ctx, r.Client, pgBackup); err != nil {
-		return reconcile.Result{}, errors.Wrap(err, "ensure finalizers")
+	if pgBackup.Status.State != v2.BackupFailed && pgBackup.Status.State != v2.BackupSucceeded {
+		if err := ensureFinalizers(ctx, r.Client, pgBackup); err != nil {
+			return reconcile.Result{}, errors.Wrap(err, "ensure finalizers")
+		}
 	}
 
 	switch pgBackup.Status.State {

--- a/percona/controller/utils.go
+++ b/percona/controller/utils.go
@@ -82,7 +82,7 @@ func GetReadyInstancePod(ctx context.Context, c client.Client, clusterName, name
 
 type FinalizerFunc[T client.Object] func(context.Context, T) error
 
-var ErrKeepFinalizer = errors.New("should keep finalizer")
+var ErrFinalizerPending = errors.New("finalizer pending")
 
 func RunFinalizer[T client.Object](ctx context.Context, cl client.Client, obj T, finalizer string, f FinalizerFunc[T]) (bool, error) {
 	if !controllerutil.ContainsFinalizer(obj, finalizer) {
@@ -98,7 +98,7 @@ func RunFinalizer[T client.Object](ctx context.Context, cl client.Client, obj T,
 	}
 
 	if err := f(ctx, obj); err != nil {
-		if errors.Is(err, ErrKeepFinalizer) {
+		if errors.Is(err, ErrFinalizerPending) {
 			return false, nil
 		}
 		return false, errors.Wrapf(err, "run finalizer %s", finalizer)

--- a/percona/postgres/common.go
+++ b/percona/postgres/common.go
@@ -17,12 +17,15 @@ func GetPrimaryPod(ctx context.Context, cli client.Client, cr *v2.PerconaPGClust
 	// K8SPG-648: patroni v4.0.0 deprecated "master" role.
 	//            We should use "primary" instead
 	role := "primary"
-	patroniVer := gover.Must(gover.NewVersion(cr.Status.PatroniVersion))
+	patroniVer, err := gover.NewVersion(cr.Status.PatroniVersion)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get patroni version")
+	}
 	patroniVer4 := patroniVer.Compare(gover.Must(gover.NewVersion("4.0.0"))) >= 0
 	if !patroniVer4 {
 		role = "master"
 	}
-	err := cli.List(ctx, podList, &client.ListOptions{
+	err = cli.List(ctx, podList, &client.ListOptions{
 		Namespace: cr.Namespace,
 		LabelSelector: labels.SelectorFromSet(map[string]string{
 			"app.kubernetes.io/instance":             cr.Name,


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/K8SPG-714

**DESCRIPTION**
---
This PR fixes the panic on update to 2.6.0 operator

Also it fixes following issues:
- handles conflict error on `pgbackup` status update, which caused following log message: `update PGBackup status: Operation cannot be fulfilled on perconapgbackups.pgv2.percona.com \"XXX\": the object has been modified`
- resources not being applied to `patroni-version-check` pod
- reduces `patroni-version-check` pod's `terminationGracePeriod` to 5
- fixes `percona.com/delete-backup` not being removed after backup completion 

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
