### PR TITLE
configure s3 to support minio

### DIFF
--- a/cmd/extension-installer/main.go
+++ b/cmd/extension-installer/main.go
@@ -11,27 +11,30 @@ import (
 )
 
 func main() {
-	var storageType, endpoint, region, bucket, key, extensionPath string
-	var install, uninstall bool
+	var storageType, endpoint, region, bucket, key, extensionPath, uriStyle string
+	var install, uninstall, verifyTLS bool
 
 	flag.StringVar(&storageType, "type", "", "Storage type")
 	flag.StringVar(&endpoint, "endpoint", "", "Storage endpoint")
 	flag.StringVar(&region, "region", "", "Storage region")
 	flag.StringVar(&bucket, "bucket", "", "Storage bucket")
 	flag.StringVar(&extensionPath, "extension-path", "", "Extension installation path")
+	flag.StringVar(&uriStyle, "uri-style", "url", "URI style, either path or url")
+
 	flag.StringVar(&key, "key", "", "Extension archive key")
 
 	flag.BoolVar(&install, "install", false, "Install extension")
 	flag.BoolVar(&uninstall, "uninstall", false, "Uninstall extension")
+	flag.BoolVar(&verifyTLS, "verify-tls", true, "Verify TLS")
 	flag.Parse()
 
 	if (install && uninstall) || (!install && !uninstall) {
 		log.Fatalf("ERROR: set either -install or -uninstall")
 	}
 
-	log.Printf("starting extension installer for %s/%s (%s) in %s", bucket, key, storageType, region)
+	log.Printf("starting extension installer for %s/%s (%s) in %s", bucket, key, storageType, region, uriStyle, verifyTLS)
 
-	storage := initStorage(extensions.StorageType(storageType), endpoint, bucket, region)
+	storage := initStorage(extensions.StorageType(storageType), endpoint, bucket, region, uriStyle, verifyTLS)
 
 	packageName := key + ".tar.gz"
 
@@ -70,10 +73,10 @@ func main() {
 	}
 }
 
-func initStorage(storageType extensions.StorageType, endpoint, bucket, region string) extensions.ObjectGetter {
+func initStorage(storageType extensions.StorageType, endpoint, bucket, region string, uriStyle string, verifyTLS bool) extensions.ObjectGetter {
 	switch storageType {
 	case extensions.StorageTypeS3:
-		return extensions.NewS3(endpoint, region, bucket)
+		return extensions.NewS3(endpoint, region, bucket, uriStyle, verifyTLS)
 	default:
 		log.Fatalf("unknown storage type: %s", os.Getenv("STORAGE_TYPE"))
 	}

--- a/percona/extensions/s3.go
+++ b/percona/extensions/s3.go
@@ -11,13 +11,19 @@ import (
 type S3 struct {
 	Region string
 	Bucket string
-
+	uriStyle string
+	verifyTLS bool
 	svc *s3.S3
 }
 
-func NewS3(endpoint, region, bucket string) *S3 {
+func NewS3(endpoint, region, bucket string, uriStyle string, verifyTLS bool) *S3 {
 	cfg := aws.NewConfig().WithRegion(region)
-
+	if(uriStyle == "path") {
+		cfg = cfg.WithS3ForcePathStyle(true)
+	}
+	if !verifyTLS {
+		cfg = cfg.WithDisableSSL(true)
+	}
 	if endpoint != "" {
 		cfg = cfg.WithEndpoint(endpoint)
 	}
@@ -28,6 +34,8 @@ func NewS3(endpoint, region, bucket string) *S3 {
 	return &S3{
 		Region: region,
 		Bucket: bucket,
+		uriStyle: uriStyle,
+		verifyTLS: verifyTLS,
 		svc:    svc,
 	}
 }


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
*Extensions storage was not compatible with MinIO due to incorrect S3 configuration.*

**Cause:**
*The S3 client did not force path-style addressing, and SSL verification issues were preventing proper connections to the MinIO instance.*

**Solution:**
*Updated S3 configuration to support MinIO by enabling path-style addressing and allowing optional TLS verification settings..*

**CHECKLIST**

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PG version?
- [x] Does the change support oldest and newest supported Kubernetes version?
