### PR TITLE
K8SPG-637: add `internal.` prefix to operator finalizers

### DIFF
--- a/e2e-tests/tests/finalizers/01-assert.yaml
+++ b/e2e-tests/tests/finalizers/01-assert.yaml
@@ -124,7 +124,7 @@ metadata:
   finalizers:
   - percona.com/delete-pvc
   - percona.com/delete-ssl
-  - percona.com/stop-watchers
+  - internal.percona.com/stop-watchers
 status:
   pgbouncer:
     ready: 3

--- a/e2e-tests/tests/finalizers/03-assert.yaml
+++ b/e2e-tests/tests/finalizers/03-assert.yaml
@@ -124,7 +124,7 @@ metadata:
   finalizers:
   - percona.com/delete-pvc
   - percona.com/delete-ssl
-  - percona.com/stop-watchers
+  - internal.percona.com/stop-watchers
 status:
   pgbouncer:
     ready: 3

--- a/percona/naming/finalizers.go
+++ b/percona/naming/finalizers.go
@@ -4,12 +4,18 @@ package naming
 const (
 	FinalizerDeletePVC     = PrefixPercona + "delete-pvc"
 	FinalizerDeleteSSL     = PrefixPercona + "delete-ssl"
-	FinalizerStopWatchers  = PrefixPercona + "stop-watchers" //nolint:gosec
+	FinalizerStopWatchers  = PrefixPerconaInternal + "stop-watchers" //nolint:gosec
 	FinalizerDeleteBackups = PrefixPercona + "delete-backups"
+
+	FinalizerStopWatchersDeprecated = PrefixPercona + "stop-watchers" //nolint:gosec
 )
 
 // PerconaPGRestore finalizers
 const (
-	FinalizerDeleteRestore = PrefixPercona + "delete-restore" //nolint:gosec
-	FinalizerDeleteBackup  = PrefixPercona + "delete-backup"  //nolint:gosec
+	FinalizerDeleteRestore = PrefixPerconaInternal + "delete-restore" //nolint:gosec
+)
+
+// PerconaPGBackup finalizers
+const (
+	FinalizerDeleteBackup = PrefixPerconaInternal + "delete-backup" //nolint:gosec
 )

--- a/percona/naming/prefix.go
+++ b/percona/naming/prefix.go
@@ -3,9 +3,10 @@ package naming
 import "strings"
 
 const (
-	PrefixPercona     = "percona.com/"
-	PrefixPerconaPGV2 = "pgv2.percona.com/"
-	PrefixCrunchy     = "postgres-operator.crunchydata.com/"
+	PrefixPercona         = "percona.com/"
+	PrefixPerconaInternal = "internal." + PrefixPercona
+	PrefixPerconaPGV2     = "pgv2.percona.com/"
+	PrefixCrunchy         = "postgres-operator.crunchydata.com/"
 )
 
 func ToCrunchyAnnotation(annotation string) string {


### PR DESCRIPTION
[![K8SPG-637](https://badgen.net/badge/JIRA/K8SPG-637/green)](https://jira.percona.com/browse/K8SPG-637) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPG-637

**DESCRIPTION**
---
This PR adds an `internal.` prefix to finalizers that are used only by the operator and are not intended for user use:
- `percona.com/stop-watchers` => `internal.percona.com/stop-watchers`
- `percona.com/delete-backup` => `internal.percona.com/delete-backup`
- `percona.com/delete-restore` => `internal.percona.com/delete-restore`

The change from `percona.com/stop-watchers` to `internal.percona.com/stop-watchers` will occur when upgrading to the new operator version, not after the `crVersion` bump.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PG version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-637]: https://perconadev.atlassian.net/browse/K8SPG-637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ