### PR TITLE
CLOUD-881 - Standardize images in release_versions

### DIFF
--- a/e2e-tests/release_versions
+++ b/e2e-tests/release_versions
@@ -3,22 +3,27 @@ IMAGE_OPERATOR=percona/percona-postgresql-operator:2.6.0
 
 IMAGE_POSTGRESQL17=percona/percona-postgresql-operator:2.6.0-ppg17.2-postgres
 IMAGE_PGBOUNCER17=percona/percona-postgresql-operator:2.6.0-ppg17.2-pgbouncer1.23.1
+IMAGE_POSTGIS17=percona/percona-postgresql-operator:2.6.0-ppg17.2-postgres-gis3.3.7
 IMAGE_BACKREST17=percona/percona-postgresql-operator:2.6.0-ppg17.2-pgbackrest2.54.0
 
 IMAGE_POSTGRESQL16=percona/percona-postgresql-operator:2.6.0-ppg16.6-postgres
 IMAGE_PGBOUNCER16=percona/percona-postgresql-operator:2.6.0-ppg16.6-pgbouncer1.23.1
+IMAGE_POSTGIS16=percona/percona-postgresql-operator:2.6.0-ppg16.6-postgres-gis3.3.7
 IMAGE_BACKREST16=percona/percona-postgresql-operator:2.6.0-ppg16.6-pgbackrest2.54.0
 
 IMAGE_POSTGRESQL15=percona/percona-postgresql-operator:2.6.0-ppg15.10-postgres
 IMAGE_PGBOUNCER15=percona/percona-postgresql-operator:2.6.0-ppg15.10-pgbouncer1.23.1
+IMAGE_POSTGIS15=percona/percona-postgresql-operator:2.6.0-ppg15.10-postgres-gis3.3.7
 IMAGE_BACKREST15=percona/percona-postgresql-operator:2.6.0-ppg15.10-pgbackrest2.54.0
 
 IMAGE_POSTGRESQL14=percona/percona-postgresql-operator:2.6.0-ppg14.15-postgres
 IMAGE_PGBOUNCER14=percona/percona-postgresql-operator:2.6.0-ppg14.15-pgbouncer1.23.1
+IMAGE_POSTGIS14=percona/percona-postgresql-operator:2.6.0-ppg14.15-postgres-gis3.3.7
 IMAGE_BACKREST14=percona/percona-postgresql-operator:2.6.0-ppg14.15-pgbackrest2.54.0
 
 IMAGE_POSTGRESQL13=percona/percona-postgresql-operator:2.6.0-ppg13.18-postgres
 IMAGE_PGBOUNCER13=percona/percona-postgresql-operator:2.6.0-ppg13.18-pgbouncer1.23.1
+IMAGE_POSTGIS13=percona/percona-postgresql-operator:2.6.0-ppg13.18-postgres-gis3.3.7
 IMAGE_BACKREST13=percona/percona-postgresql-operator:2.6.0-ppg13.18-pgbackrest2.54.0
 
 IMAGE_UPGRADE=percona/percona-postgresql-operator:2.6.0-upgrade


### PR DESCRIPTION
[![CLOUD-881](https://badgen.net/badge/JIRA/CLOUD-881/green)](https://jira.percona.com/browse/CLOUD-881) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Rename IMAGE_PGBACKREST* to IMAGE_BACKREST* for uniformity Rename MINIKUBE_REL to MINIKUBE_MAX for uniformity

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[CLOUD-881]: https://perconadev.atlassian.net/browse/CLOUD-881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ