### PR TITLE
K8SPG-651: wait longer for migration-backup-s3-pgbackrest-restore

### DIFF
--- a/e2e-tests/tests/migration-backup-s3/09-deploy-cluster.yaml
+++ b/e2e-tests/tests/migration-backup-s3/09-deploy-cluster.yaml
@@ -22,6 +22,14 @@ commands:
         ' - |
       kubectl -n $NAMESPACE apply -f -
 
-      sleep 5
+      wait_time=20
+      retry=0
+      until [[ $(kubectl get job -n $NAMESPACE | grep 'migration-backup-s3-pgbackrest-restore') ]]; do
+        sleep 1
+        let retry+=1
+        if [[ $retry -ge $wait_time ]]; then
+          exit 1
+        fi
+      done
       kubectl -n $NAMESPACE wait --for=condition=Complete job/migration-backup-s3-pgbackrest-restore --timeout=360s
     timeout: 300


### PR DESCRIPTION
[![K8SPG-651](https://badgen.net/badge/JIRA/K8SPG-651/green)](https://jira.percona.com/browse/K8SPG-651) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
migration-backup-s3 test fails on step 09 because it takes more than 5 sec for `migration-backup-s3-pgbackrest-restore` job to be created.  As a result when we run `kubectl -n $NAMESPACE wait --for=condition=Complete` there is no object and test fails.

**Solution:**
Wait for longer time before checking restore job completion,

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-651]: https://perconadev.atlassian.net/browse/K8SPG-651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ