### PR TITLE
K8SPG-651: increase timeout for demand-backup cluster deletion

### DIFF
--- a/e2e-tests/tests/demand-backup/25-delete-cluster-with-finalizer.yaml
+++ b/e2e-tests/tests/demand-backup/25-delete-cluster-with-finalizer.yaml
@@ -17,3 +17,4 @@ commands:
       fi
 
       kubectl create configmap -n "${NAMESPACE}" 25-pg-backup-objects --from-literal=data="${data}"
+    timeout: 360


### PR DESCRIPTION
[![K8SPG-651](https://badgen.net/badge/JIRA/K8SPG-651/green)](https://jira.percona.com/browse/K8SPG-651) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
It takes longer than default 180 sec timeout to delete cluster and execute all the finalizers. As a result test fails due to timeout exceeded.


**Solution:**
Increase timeout for delete-cluster-with-finalizer step to 360 sec.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-651]: https://perconadev.atlassian.net/browse/K8SPG-651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ