### PR TITLE
K8SPG-651: add retry for qan mentics and increase timeout for st6

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ void createCluster(String CLUSTER_SUFFIX) {
                 gcloud auth activate-service-account --key-file $CLIENT_SECRET_FILE
                 gcloud config set project $GCP_PROJECT
                 gcloud container clusters list --filter $CLUSTER_NAME-${CLUSTER_SUFFIX} --zone $region --format='csv[no-heading](name)' | xargs gcloud container clusters delete --zone $region --quiet || true
-                gcloud container clusters create --zone $region $CLUSTER_NAME-${CLUSTER_SUFFIX} --cluster-version=1.28 --machine-type=n1-standard-4 --preemptible --disk-size 30 --num-nodes=\$NODES_NUM --network=jenkins-vpc --subnetwork=jenkins-${CLUSTER_SUFFIX} --no-enable-autoupgrade --cluster-ipv4-cidr=/21 --labels delete-cluster-after-hours=6 --enable-ip-alias && \
+                gcloud container clusters create --zone $region $CLUSTER_NAME-${CLUSTER_SUFFIX} --cluster-version=1.29 --machine-type=n1-standard-4 --preemptible --disk-size 30 --num-nodes=\$NODES_NUM --network=jenkins-vpc --subnetwork=jenkins-${CLUSTER_SUFFIX} --no-enable-autoupgrade --cluster-ipv4-cidr=/21 --labels delete-cluster-after-hours=6 --enable-ip-alias && \
                 kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user jenkins@"$GCP_PROJECT".iam.gserviceaccount.com || ret_val=\$?
                 if [ \${ret_val} -eq 0 ]; then break; fi
                 ret_num=\$((ret_num + 1))

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -386,9 +386,19 @@ get_metric_values() {
 	local end=$($date -u "+%s")
 	local endpoint=$(get_service_ip monitoring-service)
 
-	curl -s -k -H "Authorization: Bearer ${api_key}" "https://$endpoint/graph/api/datasources/proxy/1/api/v1/query_range?query=min%28$metric%7Bnode_name%3D%7E%22$instance%22%7d%20or%20$metric%7Bnode_name%3D%7E%22$instance%22%7D%29&start=$start&end=$end&step=60" \
+	local wait_count=20
+	local retry=0
+	until [[ $(curl -s -k -H "Authorization: Bearer ${api_key}" "https://$endpoint/graph/api/datasources/proxy/1/api/v1/query_range?query=min%28$metric%7Bnode_name%3D%7E%22$instance%22%7d%20or%20$metric%7Bnode_name%3D%7E%22$instance%22%7D%29&start=$start&end=$end&step=60" \
 		| jq '.data.result[0].values[][1]' \
-		| grep '^"[0-9]'
+		| grep '^"[0-9]') ]]; do
+	sleep 2
+	local start=$($date -u "+%s" -d "-5 minute")
+	local end=$($date -u "+%s")
+	let retry+=1
+	if [[ $retry -ge $wait_count ]]; then
+		exit 1
+	fi
+	done
 }
 
 get_qan20_values() {

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -391,13 +391,13 @@ get_metric_values() {
 	until [[ $(curl -s -k -H "Authorization: Bearer ${api_key}" "https://$endpoint/graph/api/datasources/proxy/1/api/v1/query_range?query=min%28$metric%7Bnode_name%3D%7E%22$instance%22%7d%20or%20$metric%7Bnode_name%3D%7E%22$instance%22%7D%29&start=$start&end=$end&step=60" \
 		| jq '.data.result[0].values[][1]' \
 		| grep '^"[0-9]') ]]; do
-	sleep 2
-	local start=$($date -u "+%s" -d "-5 minute")
-	local end=$($date -u "+%s")
-	let retry+=1
-	if [[ $retry -ge $wait_count ]]; then
-		exit 1
-	fi
+		sleep 2
+		local start=$($date -u "+%s" -d "-5 minute")
+		local end=$($date -u "+%s")
+		let retry+=1
+		if [[ $retry -ge $wait_count ]]; then
+			exit 1
+		fi
 	done
 }
 

--- a/e2e-tests/tests/monitoring/06-check-pgstatstatements-query-source.yaml
+++ b/e2e-tests/tests/monitoring/06-check-pgstatstatements-query-source.yaml
@@ -15,3 +15,4 @@ commands:
       primary=$(get_pod_by_role monitoring primary name)
       res=$(kubectl -n ${NAMESPACE} exec ${primary} -- bash -c 'psql -c "SELECT extname FROM pg_extension;"')
       echo ${res} | grep -q pg_stat_statements
+    timeout: 360


### PR DESCRIPTION
[![K8SPG-651](https://badgen.net/badge/JIRA/K8SPG-651/green)](https://jira.percona.com/browse/K8SPG-651) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Monitoring test fails because the metrics are not present yet in PMM when we try to retrieve them.

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
Add retry to wait till first metrics are inserted.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-651]: https://perconadev.atlassian.net/browse/K8SPG-651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ