### PR TITLE
Fix patroni-version-check

### DIFF
--- a/build/crd/percona/generated/pgv2.percona.com_perconapgclusters.yaml
+++ b/build/crd/percona/generated/pgv2.percona.com_perconapgclusters.yaml
@@ -17531,6 +17531,8 @@ spec:
                 type: object
               postgres:
                 properties:
+                  imageID:
+                    type: string
                   instances:
                     items:
                       properties:

--- a/config/crd/bases/pgv2.percona.com_perconapgclusters.yaml
+++ b/config/crd/bases/pgv2.percona.com_perconapgclusters.yaml
@@ -17937,6 +17937,8 @@ spec:
                 type: object
               postgres:
                 properties:
+                  imageID:
+                    type: string
                   instances:
                     items:
                       properties:

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -18230,6 +18230,8 @@ spec:
                 type: object
               postgres:
                 properties:
+                  imageID:
+                    type: string
                   instances:
                     items:
                       properties:

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -18230,6 +18230,8 @@ spec:
                 type: object
               postgres:
                 properties:
+                  imageID:
+                    type: string
                   instances:
                     items:
                       properties:

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -18230,6 +18230,8 @@ spec:
                 type: object
               postgres:
                 properties:
+                  imageID:
+                    type: string
                   instances:
                     items:
                       properties:

--- a/percona/watcher/wal.go
+++ b/percona/watcher/wal.go
@@ -61,7 +61,7 @@ func WatchCommitTimestamps(ctx context.Context, cli client.Client, eventChan cha
 				return
 			}
 
-			latestBackup, err := getLatestBackup(ctx, cli, cr)
+			latestBackup, err := getLatestBackup(ctx, cli, localCr)
 			if err != nil {
 				if !errors.Is(err, errRunningBackup) && !errors.Is(err, errNoBackups) {
 					log.Error(err, "get latest backup")
@@ -70,7 +70,7 @@ func WatchCommitTimestamps(ctx context.Context, cli client.Client, eventChan cha
 				continue
 			}
 
-			ts, err := GetLatestCommitTimestamp(ctx, cli, execCli, cr, latestBackup)
+			ts, err := GetLatestCommitTimestamp(ctx, cli, execCli, localCr, latestBackup)
 			if err != nil {
 				switch {
 				case errors.Is(err, PrimaryPodNotFound) && localCr.Status.State != pgv2.AppStateReady:

--- a/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
+++ b/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
@@ -401,6 +401,9 @@ type PostgresStatus struct {
 
 	// +optional
 	Version int `json:"version"`
+
+	// +optional
+	ImageID string `json:"imageID"`
 }
 
 type PGBouncerStatus struct {


### PR DESCRIPTION
**DESCRIPTION**
---
**Problem:**
*The operator triggers the `patroni-version-check` only when the `.spec.postgresVersion` field is updated. However, if the user updates the images without modifying this field, the version check is not triggered, leading to an incorrect patroni version in the `.status`. This also results in a persistent error: `get latest commit timestamp: primary pod not found`.*

**Solution:**
*Start the patroni-version-check pod after all instance pods have been updated with the new image. The operator will determine this by comparing the new `.status.postgres.imageID` field with the image IDs of the instance pods.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
