### PR TITLE
Allow specifying sidecars and env vars for the repo host

### DIFF
--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgbackrest_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/pgbackrest_types.go
@@ -231,6 +231,15 @@ type PGBackRestRepoHost struct {
 	// +optional
 	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 
+	// Custom sidecar containers for the pgBackRest repo host pod. Changing this
+	// value causes the repo host to restart.
+	// +optional
+	Containers []corev1.Container `json:"containers,omitempty"`
+
+	// Environment variables to be set in the pgBackRest repo host container.
+	// +optional
+	Env []corev1.EnvVar `json:"env,omitempty"`
+
 	// ConfigMap containing custom SSH configuration.
 	// Deprecated: Repository hosts use mTLS for encryption, authentication, and authorization.
 	// +optional


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**

The repo host env vars and sidecars were not configurable.

**Solution:**

This PR simply adds support for env vars and sidecars in the Postgres CRD. Changes to the Helm chart are needed, and will come in a separate PR.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
