### PR TITLE
K8SPG-648: fix `patroni-version-check` behaviour on startup

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -2,6 +2,8 @@ apiVersion: pgv2.percona.com/v2
 kind: PerconaPGCluster
 metadata:
   name: cluster1
+#  annotations:
+#    pgv2.percona.com/custom-patroni-version: "4"
 #  finalizers:
 #  - percona.com/delete-pvc
 #  - percona.com/delete-ssl

--- a/percona/controller/pgcluster/controller.go
+++ b/percona/controller/pgcluster/controller.go
@@ -372,7 +372,7 @@ func (r *PGClusterReconciler) reconcilePatroniVersionCheck(ctx context.Context, 
 
 	// If the imageIDs slice contains the imageID from the status, we skip checking the Patroni version.
 	// This ensures that the Patroni version is only checked after all pods have been updated.
-	if len(imageIDs) == 0 || (slices.Contains(imageIDs, cr.Status.Postgres.ImageID) && cr.Status.PatroniVersion != "") {
+	if (len(imageIDs) == 0 || slices.Contains(imageIDs, cr.Status.Postgres.ImageID)) && cr.Status.PatroniVersion != "" {
 		cr.Annotations[pNaming.AnnotationPatroniVersion] = cr.Status.PatroniVersion
 		return nil
 	}

--- a/percona/controller/pgcluster/controller.go
+++ b/percona/controller/pgcluster/controller.go
@@ -335,9 +335,8 @@ func (r *PGClusterReconciler) reconcilePatroniVersionCheck(ctx context.Context, 
 		cr.Annotations = make(map[string]string)
 	}
 
-	// This annotation is used for unit-tests only. Allows to skip the patroni version check
-	if _, ok := cr.Annotations[pNaming.InternalAnnotationDisablePatroniVersionCheck]; ok {
-		cr.Annotations[pNaming.AnnotationPatroniVersion] = cr.Status.PatroniVersion
+	if patroniVersion, ok := cr.Annotations[pNaming.AnnotationCustomPatroniVersion]; ok {
+		cr.Annotations[pNaming.AnnotationPatroniVersion] = patroniVersion
 		return nil
 	}
 

--- a/percona/controller/pgcluster/controller.go
+++ b/percona/controller/pgcluster/controller.go
@@ -17,6 +17,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -371,7 +372,7 @@ func (r *PGClusterReconciler) reconcilePatroniVersionCheck(ctx context.Context, 
 
 	// If the imageIDs slice contains the imageID from the status, we skip checking the Patroni version.
 	// This ensures that the Patroni version is only checked after all pods have been updated.
-	if slices.Contains(imageIDs, cr.Status.Postgres.ImageID) && cr.Status.PatroniVersion != "" {
+	if len(imageIDs) == 0 || (slices.Contains(imageIDs, cr.Status.Postgres.ImageID) && cr.Status.PatroniVersion != "") {
 		cr.Annotations[pNaming.AnnotationPatroniVersion] = cr.Status.PatroniVersion
 		return nil
 	}
@@ -404,13 +405,23 @@ func (r *PGClusterReconciler) reconcilePatroniVersionCheck(ctx context.Context, 
 							"bash",
 						},
 						Args: []string{
-							"-c", "sleep 300",
+							"-c", "sleep 60",
 						},
 						Resources: cr.Spec.InstanceSets[0].Resources,
 					},
 				},
 				SecurityContext:               cr.Spec.InstanceSets[0].SecurityContext,
 				TerminationGracePeriodSeconds: ptr.To(int64(5)),
+				Resources: &corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("64Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("50m"),
+						corev1.ResourceMemory: resource.MustParse("32Mi"),
+					},
+				},
 			},
 		}
 

--- a/percona/controller/pgcluster/testutils_test.go
+++ b/percona/controller/pgcluster/testutils_test.go
@@ -98,9 +98,8 @@ func readTestCR(name, namespace, testFile string) (*v2.PerconaPGCluster, error) 
 	if cr.Annotations == nil {
 		cr.Annotations = make(map[string]string)
 	}
-	cr.Annotations[pNaming.InternalAnnotationDisablePatroniVersionCheck] = "true"
+	cr.Annotations[pNaming.AnnotationCustomPatroniVersion] = "4.0.0"
 	cr.Status.Postgres.Version = cr.Spec.PostgresVersion
-	cr.Status.PatroniVersion = "4.0.0"
 	return cr, nil
 }
 
@@ -120,10 +119,9 @@ func readDefaultCR(name, namespace string) (*v2.PerconaPGCluster, error) {
 	if cr.Annotations == nil {
 		cr.Annotations = make(map[string]string)
 	}
-	cr.Annotations[pNaming.InternalAnnotationDisablePatroniVersionCheck] = "true"
+	cr.Annotations[pNaming.AnnotationCustomPatroniVersion] = "4.0.0"
 	cr.Namespace = namespace
 	cr.Status.Postgres.Version = cr.Spec.PostgresVersion
-	cr.Status.PatroniVersion = "4.0.0"
 	return cr, nil
 }
 

--- a/percona/naming/annotations.go
+++ b/percona/naming/annotations.go
@@ -40,6 +40,6 @@ const (
 
 	AnnotationPatroniVersion = PrefixPerconaPGV2 + "patroni-version"
 
-	// Should be used only for unit-testing
-	InternalAnnotationDisablePatroniVersionCheck = PrefixPerconaInternal + "patroni-version-check-disable"
+	// Special annotation to disable `patroni-version-check` by overriding the patroni version with a custom value.
+	AnnotationCustomPatroniVersion = PrefixPerconaPGV2 + "custom-patroni-version"
 )


### PR DESCRIPTION
[![K8SPG-648](https://badgen.net/badge/JIRA/K8SPG-648/green)](https://jira.percona.com/browse/K8SPG-648) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPG-648

**DESCRIPTION**
---
**Problem:**
*`patroni-version-check` is created multiple times on startup, when it should be created only once.*

**Cause:**
*Instance pods don't have `imageID`'s on startup. Operator can't find the previous `imageID` in the empty slice of pod's `imageID`'s and creates new version check.*

**Solution:**
*Add a check for an empty `imageID` slice.*

This PR adds the following resources to the `patroni-version-check` pod:
```
limits:
    cpu: 100m
    memory: 64Mi
requests:
    cpu: 50m
    memory: 32Mi
```

Also, the `pgv2.percona.com/custom-patroni-version` annotation is added to disable `patroni-version-check` by overriding the patroni version with a custom value.
```
kind: PerconaPGCluster
metadata:
  name: cluster1
  annotations:
    pgv2.percona.com/custom-patroni-version: "4"
```

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-648]: https://perconadev.atlassian.net/browse/K8SPG-648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ