### PR TITLE
K8SPG-725 add resources block to repoHost in CR

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -383,6 +383,10 @@ spec:
 #        repo3-path: /pgbackrest/postgres-operator/cluster1-multi-repo/repo3
 #        repo4-path: /pgbackrest/postgres-operator/cluster1-multi-repo/repo4
       repoHost:
+#        resources:
+#          limits:
+#            cpu: 200m
+#            memory: 128Mi
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
During the initialization of a postgres cluster, the Operator generates a repoHost StatefulSet without a resources block.
When a ResourceQuota is enforced in the namespace, the missing resources block prevents pod creation

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
Add resource block in CR.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
