### PR TITLE
K8SPG-738: Add startup log to print commit hash, branch and build time

### DIFF
--- a/build/postgres-operator/Dockerfile
+++ b/build/postgres-operator/Dockerfile
@@ -27,11 +27,11 @@ RUN mkdir -p build/_output/bin \
         apt-get update -y && apt-get install gcc-x86-64-linux-gnu -y && export CC=x86_64-linux-gnu-gcc; \
       fi \
    && CGO_ENABLED=$OPERATOR_CGO_ENABLED GOARCH=${TARGETARCH} GOOS=$GOOS GO_LDFLAGS=$GO_LDFLAGS \
-       go build -ldflags "-w -s -X main.GitCommit=$GIT_COMMIT -X main.GitBranch=$GIT_BRANCH" \
+       go build -ldflags "-w -s -X main.GitCommit=$GIT_COMMIT -X main.GitBranch=$GIT_BRANCH -X main.BuildTime=$BUILD_TIME" \
            -o build/_output/bin/postgres-operator \
                ./cmd/postgres-operator \
     && CGO_ENABLED=$EXTENSION_INSTALLER_CGO_ENABLED GOARCH=${TARGETARCH} GOOS=$GOOS GO_LDFLAGS=$GO_LDFLAGS \
-       go build -ldflags "-w -s -X main.GitCommit=$GIT_COMMIT -X main.GitBranch=$GIT_BRANCH" \
+       go build -ldflags "-w -s -X main.GitCommit=$GIT_COMMIT -X main.GitBranch=$GIT_BRANCH -X main.BuildTime=$BUILD_TIME" \
            -o build/_output/bin/extension-installer \
                ./cmd/extension-installer \
     && cp -r build/_output/bin/postgres-operator /usr/local/bin/postgres-operator \

--- a/cmd/postgres-operator/main.go
+++ b/cmd/postgres-operator/main.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	goruntime "runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -47,7 +48,12 @@ import (
 	"github.com/percona/percona-postgresql-operator/pkg/apis/postgres-operator.crunchydata.com/v1beta1"
 )
 
-var versionString string
+var (
+	GitCommit     string
+	GitBranch     string
+	BuildTime     string
+	versionString string
+)
 
 // assertNoError panics when err is not nil.
 func assertNoError(err error) {
@@ -73,6 +79,9 @@ func main() {
 	ctx := cruntime.SetupSignalHandler()
 	log := logging.FromContext(ctx)
 	log.V(1).Info("debug flag set to true")
+
+	log.Info("Manager starting up", "gitCommit", GitCommit, "gitBranch", GitBranch,
+		"buildTime", BuildTime, "goVersion", goruntime.Version(), "os", goruntime.GOOS, "arch", goruntime.GOARCH)
 
 	features := feature.NewGate()
 	err = features.SetFromMap(map[string]bool{


### PR DESCRIPTION
[![K8SPG-738](https://badgen.net/badge/JIRA/K8SPG-738/green)](https://jira.percona.com/browse/K8SPG-738) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
```
$ k logs percona-postgresql-operator-86f7cf59cd-5hs7w
2025-03-26T14:54:22.654Z        INFO    Manager starting up     {"gitCommit": "72f3dc3c1b12063e3260fc1799e3e240ffb67ab1", "gitBranch": "K8SPG-738", "buildTime": "2025-03-26T14:52:43Z", "goVersion": "go1.23.7", "os": "linux", "arch": "amd64"}
...
```


**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-738]: https://perconadev.atlassian.net/browse/K8SPG-738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ