### PR TITLE
K8SPG-654 add possibility of adding custom postgres params for PMM

### DIFF
--- a/build/crd/percona/generated/pgv2.percona.com_perconapgclusters.yaml
+++ b/build/crd/percona/generated/pgv2.percona.com_perconapgclusters.yaml
@@ -13633,6 +13633,8 @@ spec:
                     - Never
                     - IfNotPresent
                     type: string
+                  postgresParams:
+                    type: string
                   querySource:
                     default: pgstatmonitor
                     enum:

--- a/config/crd/bases/pgv2.percona.com_perconapgclusters.yaml
+++ b/config/crd/bases/pgv2.percona.com_perconapgclusters.yaml
@@ -14038,6 +14038,8 @@ spec:
                     - Never
                     - IfNotPresent
                     type: string
+                  postgresParams:
+                    type: string
                   querySource:
                     default: pgstatmonitor
                     enum:

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -14331,6 +14331,8 @@ spec:
                     - Never
                     - IfNotPresent
                     type: string
+                  postgresParams:
+                    type: string
                   querySource:
                     default: pgstatmonitor
                     enum:

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -471,7 +471,8 @@ spec:
 #    imagePullPolicy: IfNotPresent
     secret: cluster1-pmm-secret
     serverHost: monitoring-service
-#   customClusterName: "<string>"
+#    customClusterName: "<string>"
+#    postgresParams: "<string>"
 #    querySource: pgstatmonitor
 #  patroni:
 #    # Some values of the Liveness/Readiness probes of the patroni container are calculated using syncPeriodSeconds by the following formulas:

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -14331,6 +14331,8 @@ spec:
                     - Never
                     - IfNotPresent
                     type: string
+                  postgresParams:
+                    type: string
                   querySource:
                     default: pgstatmonitor
                     enum:

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -14331,6 +14331,8 @@ spec:
                     - Never
                     - IfNotPresent
                     type: string
+                  postgresParams:
+                    type: string
                   querySource:
                     default: pgstatmonitor
                     enum:

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -182,7 +182,8 @@ get_cr() {
 		.spec.proxy.pgBouncer.image = "'$IMAGE_PGBOUNCER'" |
 		.spec.pmm.image = "'$IMAGE_PMM_CLIENT'" |
 		.spec.pmm.secret = "'${cr_name}'-pmm-secret" |
-		.spec.pmm.customClusterName = "'${cr_name}'-pmm-custom-name"
+		.spec.pmm.customClusterName = "'${cr_name}'-pmm-custom-name" |
+		.spec.pmm.postgresParams = "--environment=dev-postgres"
 		' $DEPLOY_DIR/cr.yaml >$TEMP_DIR/cr.yaml
 
 	if [[ $OPENSHIFT ]]; then
@@ -381,7 +382,7 @@ deploy_pmm3_server() {
 			oc create rolebinding pmm-pg-operator-namespace-only --role percona-postgresql-operator --serviceaccount=$NAMESPACE:pmm-server -n "${NAMESPACE}"
 			oc patch role/percona-postgresql-operator --type json -p='[{"op":"add","path": "/rules/-","value":{"apiGroups":["security.openshift.io"],"resources":["securitycontextconstraints"],"verbs":["use"],"resourceNames":["privileged"]}}]' -n "$NAMESPACE"
 		fi
-		helm install monitoring --set imageTag=${IMAGE_PMM3_SERVER#*:} --set imageRepo=${IMAGE_PMM3_SERVER%:*} --set platform=$platform --set sa=pmm-server --set supresshttp2=false https://percona-charts.storage.googleapis.com/pmm-server-${PMM3_SERVER_VERSION}.tgz -n "$NAMESPACE"
+		helm install monitoring --set imageTag=${IMAGE_PMM3_SERVER#*:} --set imageRepo=${IMAGE_PMM3_SERVER%:*} --set platform=$platform --set sa=pmm-server --set supresshttp2=false https://percona-charts.storage.googleapis.com/pmm-server-${PMM_SERVER_VERSION}.tgz -n "$NAMESPACE"
 	else
 		platform=kubernetes
 

--- a/e2e-tests/tests/monitoring-pmm3/03-assert.yaml
+++ b/e2e-tests/tests/monitoring-pmm3/03-assert.yaml
@@ -40,6 +40,7 @@ spec:
     secret: monitoring-pmm3-pmm-secret
     serverHost: monitoring-service
     customClusterName: monitoring-pmm3-pmm-custom-name
+    postgresParams: "--environment=dev-postgres"
   port: 5432
   proxy:
     pgBouncer:

--- a/e2e-tests/tests/monitoring/03-assert.yaml
+++ b/e2e-tests/tests/monitoring/03-assert.yaml
@@ -40,6 +40,7 @@ spec:
     secret: monitoring-pmm-secret
     serverHost: monitoring-service
     customClusterName: monitoring-pmm-custom-name
+    postgresParams: "--environment=dev-postgres"
   port: 5432
   proxy:
     pgBouncer:

--- a/percona/pmm/pmm.go
+++ b/percona/pmm/pmm.go
@@ -238,10 +238,16 @@ func sidecarContainerV2(pgc *v2.PerconaPGCluster) corev1.Container {
 		if pgc.Spec.PMM.CustomClusterName != "" {
 			clusterName = pgc.Spec.PMM.CustomClusterName
 		}
-		container.Env = append(container.Env, corev1.EnvVar{
-			Name:  "CLUSTER_NAME",
-			Value: clusterName,
-		})
+		container.Env = append(container.Env,
+			corev1.EnvVar{
+				Name:  "CLUSTER_NAME",
+				Value: clusterName,
+			},
+			corev1.EnvVar{
+				Name:  "PMM_POSTGRES_PARAMS",
+				Value: pmmSpec.PostgresParams,
+			},
+		)
 	}
 
 	return container
@@ -434,6 +440,10 @@ func sidecarContainerV3(pgc *v2.PerconaPGCluster) corev1.Container {
 				Name:  "CLUSTER_NAME",
 				Value: clusterName,
 			},
+			{
+				Name:  "PMM_POSTGRES_PARAMS",
+				Value: pmmSpec.PostgresParams,
+			},
 		},
 	}
 
@@ -461,7 +471,7 @@ func agentPrerunScript(querySource v2.PMMQuerySource, pgc *v2.PerconaPGCluster) 
 
 	if pgc.CompareVersion("2.7.0") >= 0 {
 		addServiceArgs = append(addServiceArgs,
-			"--cluster=$(CLUSTER_NAME)",
+			"--cluster=$(CLUSTER_NAME)", "$PMM_POSTGRES_PARAMS",
 		)
 	}
 	addService := fmt.Sprintf("pmm-admin add postgresql %s", strings.Join(addServiceArgs, " "))

--- a/percona/pmm/pmm_test.go
+++ b/percona/pmm/pmm_test.go
@@ -19,6 +19,7 @@ func TestContainer(t *testing.T) {
 		ImagePullPolicy:          corev1.PullIfNotPresent,
 		ServerHost:               "pmm.server.local",
 		Secret:                   "pmm-secret",
+		PostgresParams:           "--environment=dev-postgres",
 		Resources:                corev1.ResourceRequirements{},
 		ContainerSecurityContext: &corev1.SecurityContext{},
 	}
@@ -144,6 +145,7 @@ func TestSidecarContainerV2(t *testing.T) {
 		ImagePullPolicy:          corev1.PullIfNotPresent,
 		ServerHost:               "pmm.server.local",
 		Secret:                   "pmm-secret",
+		PostgresParams:           "--environment=dev-postgres",
 		Resources:                corev1.ResourceRequirements{},
 		ContainerSecurityContext: &corev1.SecurityContext{},
 	}
@@ -179,7 +181,7 @@ func TestSidecarContainerV2(t *testing.T) {
 	assert.NotNil(t, container.Lifecycle.PreStop)
 	assert.Equal(t, []string{"bash", "-c", "pmm-admin unregister --force"}, container.Lifecycle.PreStop.Exec.Command)
 
-	assert.Len(t, container.Env, 32)
+	assert.Len(t, container.Env, 33)
 
 	expectedEnvVars := map[string]string{
 		"POD_NAME":                      "", // field reference is asserted separately
@@ -211,9 +213,10 @@ func TestSidecarContainerV2(t *testing.T) {
 		"DB_TYPE":                       "postgresql",
 		"DB_USER":                       v2.UserMonitoring,
 		"DB_PASS":                       "", // secret reference is asserted separately
-		"PMM_AGENT_PRERUN_SCRIPT":       "pmm-admin status --wait=10s; pmm-admin add postgresql --username=$(DB_USER) --password='$(DB_PASS)' --host=127.0.0.1 --port=5432 --tls-cert-file=/pgconf/tls/tls.crt --tls-key-file=/pgconf/tls/tls.key --tls-ca-file=/pgconf/tls/ca.crt --tls-skip-verify --skip-connection-check --metrics-mode=push --service-name=$(PMM_AGENT_SETUP_NODE_NAME) --query-source= --cluster=$(CLUSTER_NAME); pmm-admin annotate --service-name=$(PMM_AGENT_SETUP_NODE_NAME) 'Service restarted'",
+		"PMM_AGENT_PRERUN_SCRIPT":       "pmm-admin status --wait=10s; pmm-admin add postgresql --username=$(DB_USER) --password='$(DB_PASS)' --host=127.0.0.1 --port=5432 --tls-cert-file=/pgconf/tls/tls.crt --tls-key-file=/pgconf/tls/tls.key --tls-ca-file=/pgconf/tls/ca.crt --tls-skip-verify --skip-connection-check --metrics-mode=push --service-name=$(PMM_AGENT_SETUP_NODE_NAME) --query-source= --cluster=$(CLUSTER_NAME) $PMM_POSTGRES_PARAMS; pmm-admin annotate --service-name=$(PMM_AGENT_SETUP_NODE_NAME) 'Service restarted'",
 		"PMM_AGENT_PATHS_TEMPDIR":       "/tmp",
 		"CLUSTER_NAME":                  "test-cluster",
+		"PMM_POSTGRES_PARAMS":           "--environment=dev-postgres",
 	}
 
 	for _, envVar := range container.Env {
@@ -256,6 +259,7 @@ func TestSidecarContainerV3(t *testing.T) {
 		ImagePullPolicy:          corev1.PullIfNotPresent,
 		ServerHost:               "pmm.server.local",
 		Secret:                   "pmm-secret",
+		PostgresParams:           "--environment=dev-postgres",
 		Resources:                corev1.ResourceRequirements{},
 		ContainerSecurityContext: &corev1.SecurityContext{},
 	}
@@ -291,7 +295,7 @@ func TestSidecarContainerV3(t *testing.T) {
 	assert.NotNil(t, container.Lifecycle.PreStop)
 	assert.Equal(t, []string{"bash", "-c", "pmm-admin unregister --force"}, container.Lifecycle.PreStop.Exec.Command)
 
-	assert.Len(t, container.Env, 27)
+	assert.Len(t, container.Env, 28)
 
 	expectedEnvVars := map[string]string{
 		"POD_NAME":                      "", // field reference is asserted separately
@@ -318,9 +322,10 @@ func TestSidecarContainerV3(t *testing.T) {
 		"DB_TYPE":                       "postgresql",
 		"DB_USER":                       v2.UserMonitoring,
 		"DB_PASS":                       "", // secret reference is asserted separately
-		"PMM_AGENT_PRERUN_SCRIPT":       "pmm-admin status --wait=10s; pmm-admin add postgresql --username=$(DB_USER) --password='$(DB_PASS)' --host=127.0.0.1 --port=5432 --tls-cert-file=/pgconf/tls/tls.crt --tls-key-file=/pgconf/tls/tls.key --tls-ca-file=/pgconf/tls/ca.crt --tls-skip-verify --skip-connection-check --metrics-mode=push --service-name=$(PMM_AGENT_SETUP_NODE_NAME) --query-source= --cluster=$(CLUSTER_NAME); pmm-admin annotate --service-name=$(PMM_AGENT_SETUP_NODE_NAME) 'Service restarted'",
+		"PMM_AGENT_PRERUN_SCRIPT":       "pmm-admin status --wait=10s; pmm-admin add postgresql --username=$(DB_USER) --password='$(DB_PASS)' --host=127.0.0.1 --port=5432 --tls-cert-file=/pgconf/tls/tls.crt --tls-key-file=/pgconf/tls/tls.key --tls-ca-file=/pgconf/tls/ca.crt --tls-skip-verify --skip-connection-check --metrics-mode=push --service-name=$(PMM_AGENT_SETUP_NODE_NAME) --query-source= --cluster=$(CLUSTER_NAME) $PMM_POSTGRES_PARAMS; pmm-admin annotate --service-name=$(PMM_AGENT_SETUP_NODE_NAME) 'Service restarted'",
 		"PMM_AGENT_PATHS_TEMPDIR":       "/tmp",
 		"CLUSTER_NAME":                  "test-cluster",
+		"PMM_POSTGRES_PARAMS":           "--environment=dev-postgres",
 	}
 
 	for _, envVar := range container.Env {

--- a/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
+++ b/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
@@ -556,6 +556,9 @@ type PMMSpec struct {
 	// +optional
 	CustomClusterName string `json:"customClusterName,omitempty"`
 
+	// +optional
+	PostgresParams string `json:"postgresParams,omitempty"`
+
 	// +kubebuilder:validation:Required
 	Secret string `json:"secret,omitempty"`
 


### PR DESCRIPTION
[![K8SPG-654](https://badgen.net/badge/JIRA/K8SPG-654/green)](https://jira.percona.com/browse/K8SPG-654) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Allow to add custom params to pmm section 

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-654]: https://perconadev.atlassian.net/browse/K8SPG-654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ