### PR TITLE
K8SPG-753: Add field to control pg_stat_statements

### DIFF
--- a/build/crd/percona/generated/pgv2.percona.com_perconapgclusters.yaml
+++ b/build/crd/percona/generated/pgv2.percona.com_perconapgclusters.yaml
@@ -8072,6 +8072,8 @@ spec:
                         type: boolean
                       pg_stat_monitor:
                         type: boolean
+                      pg_stat_statements:
+                        type: boolean
                       pgvector:
                         type: boolean
                     type: object

--- a/config/crd/bases/pgv2.percona.com_perconapgclusters.yaml
+++ b/config/crd/bases/pgv2.percona.com_perconapgclusters.yaml
@@ -8477,6 +8477,8 @@ spec:
                         type: boolean
                       pg_stat_monitor:
                         type: boolean
+                      pg_stat_statements:
+                        type: boolean
                       pgvector:
                         type: boolean
                     type: object

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -8774,6 +8774,8 @@ spec:
                         type: boolean
                       pg_stat_monitor:
                         type: boolean
+                      pg_stat_statements:
+                        type: boolean
                       pgvector:
                         type: boolean
                     type: object

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -8774,6 +8774,8 @@ spec:
                         type: boolean
                       pg_stat_monitor:
                         type: boolean
+                      pg_stat_statements:
+                        type: boolean
                       pgvector:
                         type: boolean
                     type: object

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -8774,6 +8774,8 @@ spec:
                         type: boolean
                       pg_stat_monitor:
                         type: boolean
+                      pg_stat_statements:
+                        type: boolean
                       pgvector:
                         type: boolean
                     type: object

--- a/e2e-tests/tests/monitoring-pmm3/06-check-pgstatstatements-query-source.yaml
+++ b/e2e-tests/tests/monitoring-pmm3/06-check-pgstatstatements-query-source.yaml
@@ -17,9 +17,8 @@ commands:
       # Wait for the pg_stat_statements extension to be created
       sleep 80
 
-      kubectl -n ${NAMESPACE} exec ${primary} -- bash -c 'psql -c "SELECT * FROM pg_extension;"'
-
       primary=$(get_pod_by_role monitoring primary name)
+      kubectl -n ${NAMESPACE} exec ${primary} -- bash -c 'psql -c "SELECT * FROM pg_extension;"'
       if ! kubectl -n ${NAMESPACE} exec ${primary} -- bash -c 'psql -c "SELECT extname FROM pg_extension;"' | grep pg_stat_statements; then
         echo "pg_stat_statements is not found in pg_extension"
       fi

--- a/e2e-tests/tests/monitoring-pmm3/06-check-pgstatstatements-query-source.yaml
+++ b/e2e-tests/tests/monitoring-pmm3/06-check-pgstatstatements-query-source.yaml
@@ -7,11 +7,20 @@ commands:
 
       source ../../functions
 
-      kubectl -n ${NAMESPACE} patch perconapgcluster/monitoring-pmm3 --type=merge -p '{"spec":{"pmm":{"querySource":"pgstatstatements"}}}'
+      kubectl -n ${NAMESPACE} patch perconapgcluster/monitoring --type=merge -p '{
+        "spec":{
+          "pmm":{"querySource":"pgstatstatements"},
+          "extensions": {"builtin": {"pg_stat_statements": true }}}
+        }
+      '
 
       # Wait for the pg_stat_statements extension to be created
       sleep 80
 
-      primary=$(get_pod_by_role monitoring-pmm3 primary name)
-      res=$(kubectl -n ${NAMESPACE} exec ${primary} -- bash -c 'psql -c "SELECT extname FROM pg_extension;"')
-      echo ${res} | grep -q pg_stat_statements
+      kubectl -n ${NAMESPACE} exec ${primary} -- bash -c 'psql -c "SELECT * FROM pg_extension;"'
+
+      primary=$(get_pod_by_role monitoring primary name)
+      if ! kubectl -n ${NAMESPACE} exec ${primary} -- bash -c 'psql -c "SELECT extname FROM pg_extension;"' | grep pg_stat_statements; then
+        echo "pg_stat_statements is not found in pg_extension"
+      fi
+    timeout: 360

--- a/e2e-tests/tests/monitoring-pmm3/06-check-pgstatstatements-query-source.yaml
+++ b/e2e-tests/tests/monitoring-pmm3/06-check-pgstatstatements-query-source.yaml
@@ -7,7 +7,7 @@ commands:
 
       source ../../functions
 
-      kubectl -n ${NAMESPACE} patch perconapgcluster/monitoring --type=merge -p '{
+      kubectl -n ${NAMESPACE} patch perconapgcluster/monitoring-pmm3 --type=merge -p '{
         "spec":{
           "pmm":{"querySource":"pgstatstatements"},
           "extensions": {"builtin": {"pg_stat_statements": true }}}

--- a/e2e-tests/tests/monitoring-pmm3/06-check-pgstatstatements-query-source.yaml
+++ b/e2e-tests/tests/monitoring-pmm3/06-check-pgstatstatements-query-source.yaml
@@ -17,7 +17,7 @@ commands:
       # Wait for the pg_stat_statements extension to be created
       sleep 80
 
-      primary=$(get_pod_by_role monitoring primary name)
+      primary=$(get_pod_by_role monitoring-pmm3 primary name)
       kubectl -n ${NAMESPACE} exec ${primary} -- bash -c 'psql -c "SELECT * FROM pg_extension;"'
       if ! kubectl -n ${NAMESPACE} exec ${primary} -- bash -c 'psql -c "SELECT extname FROM pg_extension;"' | grep pg_stat_statements; then
         echo "pg_stat_statements is not found in pg_extension"

--- a/e2e-tests/tests/monitoring/06-check-pgstatstatements-query-source.yaml
+++ b/e2e-tests/tests/monitoring/06-check-pgstatstatements-query-source.yaml
@@ -17,9 +17,8 @@ commands:
       # Wait for the pg_stat_statements extension to be created
       sleep 80
 
-      kubectl -n ${NAMESPACE} exec ${primary} -- bash -c 'psql -c "SELECT * FROM pg_extension;"'
-
       primary=$(get_pod_by_role monitoring primary name)
+      kubectl -n ${NAMESPACE} exec ${primary} -- bash -c 'psql -c "SELECT * FROM pg_extension;"'
       if ! kubectl -n ${NAMESPACE} exec ${primary} -- bash -c 'psql -c "SELECT extname FROM pg_extension;"' | grep pg_stat_statements; then
         echo "pg_stat_statements is not found in pg_extension"
       fi

--- a/e2e-tests/tests/monitoring/06-check-pgstatstatements-query-source.yaml
+++ b/e2e-tests/tests/monitoring/06-check-pgstatstatements-query-source.yaml
@@ -7,12 +7,20 @@ commands:
 
       source ../../functions
 
-      kubectl -n ${NAMESPACE} patch perconapgcluster/monitoring --type=merge -p '{"spec":{"pmm":{"querySource":"pgstatstatements"}}}'
+      kubectl -n ${NAMESPACE} patch perconapgcluster/monitoring --type=merge -p '{
+        "spec":{
+          "pmm":{"querySource":"pgstatstatements"},
+          "extensions": {"builtin": {"pg_stat_statements": true }}}
+        }
+      '
 
       # Wait for the pg_stat_statements extension to be created
       sleep 80
 
+      kubectl -n ${NAMESPACE} exec ${primary} -- bash -c 'psql -c "SELECT * FROM pg_extension;"'
+
       primary=$(get_pod_by_role monitoring primary name)
-      res=$(kubectl -n ${NAMESPACE} exec ${primary} -- bash -c 'psql -c "SELECT extname FROM pg_extension;"')
-      echo ${res} | grep -q pg_stat_statements
+      if ! kubectl -n ${NAMESPACE} exec ${primary} -- bash -c 'psql -c "SELECT extname FROM pg_extension;"' | grep pg_stat_statements; then
+        echo "pg_stat_statements is not found in pg_extension"
+      fi
     timeout: 360

--- a/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
+++ b/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
@@ -225,6 +225,9 @@ func (cr *PerconaPGCluster) Default() {
 	if cr.Spec.Extensions.BuiltIn.PGStatMonitor == nil {
 		cr.Spec.Extensions.BuiltIn.PGStatMonitor = &t
 	}
+	if cr.Spec.Extensions.BuiltIn.PGStatStatements == nil {
+		cr.Spec.Extensions.BuiltIn.PGStatStatements = &f
+	}
 	if cr.Spec.Extensions.BuiltIn.PGAudit == nil {
 		cr.Spec.Extensions.BuiltIn.PGAudit = &t
 	}
@@ -355,6 +358,7 @@ func (cr *PerconaPGCluster) ToCrunchy(ctx context.Context, postgresCluster *crun
 	postgresCluster.Spec.Proxy = cr.Spec.Proxy.ToCrunchy()
 
 	postgresCluster.Spec.Extensions.PGStatMonitor = *cr.Spec.Extensions.BuiltIn.PGStatMonitor
+	postgresCluster.Spec.Extensions.PGStatStatements = *cr.Spec.Extensions.BuiltIn.PGStatStatements
 	postgresCluster.Spec.Extensions.PGAudit = *cr.Spec.Extensions.BuiltIn.PGAudit
 	postgresCluster.Spec.Extensions.PGVector = *cr.Spec.Extensions.BuiltIn.PGVector
 	postgresCluster.Spec.Extensions.PGRepack = *cr.Spec.Extensions.BuiltIn.PGRepack
@@ -605,10 +609,11 @@ type CustomExtensionsStorageSpec struct {
 }
 
 type BuiltInExtensionsSpec struct {
-	PGStatMonitor *bool `json:"pg_stat_monitor,omitempty"`
-	PGAudit       *bool `json:"pg_audit,omitempty"`
-	PGVector      *bool `json:"pgvector,omitempty"`
-	PGRepack      *bool `json:"pg_repack,omitempty"`
+	PGStatMonitor    *bool `json:"pg_stat_monitor,omitempty"`
+	PGStatStatements *bool `json:"pg_stat_statements,omitempty"`
+	PGAudit          *bool `json:"pg_audit,omitempty"`
+	PGVector         *bool `json:"pgvector,omitempty"`
+	PGRepack         *bool `json:"pg_repack,omitempty"`
 }
 
 type ExtensionsSpec struct {

--- a/pkg/apis/pgv2.percona.com/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/pgv2.percona.com/v2/zz_generated.deepcopy.go
@@ -44,6 +44,11 @@ func (in *BuiltInExtensionsSpec) DeepCopyInto(out *BuiltInExtensionsSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.PGStatStatements != nil {
+		in, out := &in.PGStatStatements, &out.PGStatStatements
+		*out = new(bool)
+		**out = **in
+	}
 	if in.PGAudit != nil {
 		in, out := &in.PGAudit, &out.PGAudit
 		*out = new(bool)


### PR DESCRIPTION
[![K8SPG-753](https://badgen.net/badge/JIRA/K8SPG-753/green)](https://jira.percona.com/browse/K8SPG-753) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
Add an explicit field to control `pg_stat_statements` extension.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-753]: https://perconadev.atlassian.net/browse/K8SPG-753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ