### PR TITLE
K8SPG-761: add support for the `PGO_WORKERS` env var

### DIFF
--- a/cmd/postgres-operator/main.go
+++ b/cmd/postgres-operator/main.go
@@ -41,7 +41,6 @@ import (
 	"github.com/percona/percona-postgresql-operator/percona/controller/pgcluster"
 	"github.com/percona/percona-postgresql-operator/percona/controller/pgrestore"
 	perconaPGUpgrade "github.com/percona/percona-postgresql-operator/percona/controller/pgupgrade"
-	"github.com/percona/percona-postgresql-operator/percona/k8s"
 	perconaRuntime "github.com/percona/percona-postgresql-operator/percona/runtime"
 	"github.com/percona/percona-postgresql-operator/percona/utils/registry"
 	v2 "github.com/percona/percona-postgresql-operator/pkg/apis/pgv2.percona.com/v2"
@@ -111,15 +110,13 @@ func main() {
 	// deprecation warnings when using an older version of a resource for backwards compatibility).
 	rest.SetDefaultWarningHandler(rest.NoWarnings{})
 
-	namespaces, err := k8s.GetWatchNamespace()
+	options, err := initManager(ctx)
 	assertNoError(err)
 
 	mgr, err := perconaRuntime.CreateRuntimeManager(
-		namespaces,
 		cfg,
-		false,
-		false,
 		features,
+		options,
 	)
 	assertNoError(err)
 
@@ -260,8 +257,8 @@ func addControllersToManager(ctx context.Context, mgr manager.Manager) error {
 
 //+kubebuilder:rbac:groups="coordination.k8s.io",resources="leases",verbs={get,create,update}
 
-func initManager() (runtime.Options, error) {
-	log := logging.FromContext(context.Background())
+func initManager(ctx context.Context) (runtime.Options, error) {
+	log := logging.FromContext(ctx)
 
 	options := runtime.Options{}
 	options.Cache.SyncPeriod = initialize.Pointer(time.Hour)

--- a/cmd/postgres-operator/main.go
+++ b/cmd/postgres-operator/main.go
@@ -276,6 +276,10 @@ func initManager(ctx context.Context) (runtime.Options, error) {
 		options.LeaderElection = true
 		options.LeaderElectionID = lease
 		options.LeaderElectionNamespace = os.Getenv("PGO_NAMESPACE")
+	} else {
+		// K8SPG-761
+		options.LeaderElection = true
+		options.LeaderElectionID = perconaRuntime.ElectionID
 	}
 
 	// Check PGO_TARGET_NAMESPACE for backwards compatibility with
@@ -314,10 +318,6 @@ func initManager(ctx context.Context) (runtime.Options, error) {
 			log.Error(err, "PGO_WORKERS must be a positive number")
 		}
 	}
-
-	// K8SPG-761
-	options.LeaderElection = true
-	options.LeaderElectionID = perconaRuntime.ElectionID
 
 	return options, nil
 }

--- a/cmd/postgres-operator/main.go
+++ b/cmd/postgres-operator/main.go
@@ -113,9 +113,6 @@ func main() {
 	options, err := initManager(ctx)
 	assertNoError(err)
 
-	options.LeaderElection = true
-	options.LeaderElectionID = perconaRuntime.ElectionID
-
 	mgr, err := perconaRuntime.CreateRuntimeManager(
 		cfg,
 		features,
@@ -317,6 +314,10 @@ func initManager(ctx context.Context) (runtime.Options, error) {
 			log.Error(err, "PGO_WORKERS must be a positive number")
 		}
 	}
+
+	// K8SPG-761
+	options.LeaderElection = true
+	options.LeaderElectionID = perconaRuntime.ElectionID
 
 	return options, nil
 }

--- a/cmd/postgres-operator/main.go
+++ b/cmd/postgres-operator/main.go
@@ -113,6 +113,9 @@ func main() {
 	options, err := initManager(ctx)
 	assertNoError(err)
 
+	options.LeaderElection = true
+	options.LeaderElectionID = perconaRuntime.ElectionID
+
 	mgr, err := perconaRuntime.CreateRuntimeManager(
 		cfg,
 		features,

--- a/cmd/postgres-operator/main_test.go
+++ b/cmd/postgres-operator/main_test.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -14,8 +15,9 @@ import (
 )
 
 func TestInitManager(t *testing.T) {
+	ctx := context.Background()
 	t.Run("Defaults", func(t *testing.T) {
-		options, err := initManager()
+		options, err := initManager(ctx)
 		assert.NilError(t, err)
 
 		if assert.Check(t, options.Cache.SyncPeriod != nil) {
@@ -48,7 +50,7 @@ func TestInitManager(t *testing.T) {
 		t.Run("Invalid", func(t *testing.T) {
 			t.Setenv("PGO_CONTROLLER_LEASE_NAME", "INVALID_NAME")
 
-			options, err := initManager()
+			options, err := initManager(ctx)
 			assert.ErrorContains(t, err, "PGO_CONTROLLER_LEASE_NAME")
 			assert.ErrorContains(t, err, "invalid")
 
@@ -59,7 +61,7 @@ func TestInitManager(t *testing.T) {
 		t.Run("Valid", func(t *testing.T) {
 			t.Setenv("PGO_CONTROLLER_LEASE_NAME", "valid-name")
 
-			options, err := initManager()
+			options, err := initManager(ctx)
 			assert.NilError(t, err)
 			assert.Assert(t, options.LeaderElection == true)
 			assert.Equal(t, options.LeaderElectionNamespace, "test-namespace")
@@ -70,7 +72,7 @@ func TestInitManager(t *testing.T) {
 	t.Run("PGO_TARGET_NAMESPACE", func(t *testing.T) {
 		t.Setenv("PGO_TARGET_NAMESPACE", "some-such")
 
-		options, err := initManager()
+		options, err := initManager(ctx)
 		assert.NilError(t, err)
 		assert.Assert(t, cmp.Len(options.Cache.DefaultNamespaces, 1),
 			"expected only one configured namespace")
@@ -81,7 +83,7 @@ func TestInitManager(t *testing.T) {
 	t.Run("PGO_TARGET_NAMESPACES", func(t *testing.T) {
 		t.Setenv("PGO_TARGET_NAMESPACES", "some-such,another-one")
 
-		options, err := initManager()
+		options, err := initManager(ctx)
 		assert.NilError(t, err)
 		assert.Assert(t, cmp.Len(options.Cache.DefaultNamespaces, 2),
 			"expect two configured namespaces")
@@ -95,7 +97,7 @@ func TestInitManager(t *testing.T) {
 			for _, v := range []string{"-3", "0", "3.14"} {
 				t.Setenv("PGO_WORKERS", v)
 
-				options, err := initManager()
+				options, err := initManager(ctx)
 				assert.NilError(t, err)
 				assert.DeepEqual(t, options.Controller.GroupKindConcurrency,
 					map[string]int{
@@ -107,7 +109,7 @@ func TestInitManager(t *testing.T) {
 		t.Run("Valid", func(t *testing.T) {
 			t.Setenv("PGO_WORKERS", "19")
 
-			options, err := initManager()
+			options, err := initManager(ctx)
 			assert.NilError(t, err)
 			assert.DeepEqual(t, options.Controller.GroupKindConcurrency,
 				map[string]int{

--- a/cmd/postgres-operator/main_test.go
+++ b/cmd/postgres-operator/main_test.go
@@ -32,12 +32,14 @@ func TestInitManager(t *testing.T) {
 			})
 
 		assert.Assert(t, options.Cache.DefaultNamespaces == nil)
-		assert.Assert(t, options.LeaderElection == false)
+		assert.Assert(t, options.LeaderElection == true)
 
 		{
 			options.Cache.SyncPeriod = nil
 			options.Controller.GroupKindConcurrency = nil
 			options.HealthProbeBindAddress = ""
+			options.LeaderElection = false
+			options.LeaderElectionID = ""
 
 			assert.Assert(t, reflect.ValueOf(options).IsZero(),
 				"expected remaining fields to be unset:\n%+v", options)

--- a/config/manager/default/manager.yaml
+++ b/config/manager/default/manager.yaml
@@ -35,6 +35,8 @@ spec:
             value: INFO
           - name: DISABLE_TELEMETRY
             value: "false"
+          - name: PGO_WORKERS
+            value: "1"
         ports:
           - containerPort: 8080
             name: metrics

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -47675,6 +47675,8 @@ spec:
           value: INFO
         - name: DISABLE_TELEMETRY
           value: "false"
+        - name: PGO_WORKERS
+          value: "1"
         image: perconalab/percona-postgresql-operator:main
         imagePullPolicy: Always
         livenessProbe:

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -47673,6 +47673,8 @@ spec:
           value: INFO
         - name: DISABLE_TELEMETRY
           value: "false"
+        - name: PGO_WORKERS
+          value: "1"
         image: perconalab/percona-postgresql-operator:main
         imagePullPolicy: Always
         livenessProbe:

--- a/deploy/cw-operator.yaml
+++ b/deploy/cw-operator.yaml
@@ -42,6 +42,8 @@ spec:
           value: INFO
         - name: DISABLE_TELEMETRY
           value: "false"
+        - name: PGO_WORKERS
+          value: "1"
         image: perconalab/percona-postgresql-operator:main
         imagePullPolicy: Always
         livenessProbe:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -45,6 +45,8 @@ spec:
           value: INFO
         - name: DISABLE_TELEMETRY
           value: "false"
+        - name: PGO_WORKERS
+          value: "1"
         image: perconalab/percona-postgresql-operator:main
         imagePullPolicy: Always
         livenessProbe:

--- a/percona/runtime/runtime.go
+++ b/percona/runtime/runtime.go
@@ -18,14 +18,12 @@ import (
 // default refresh interval in minutes
 const refreshInterval time.Duration = 60 * time.Minute
 
-const electionID string = "08db3feb.percona.com"
+const ElectionID string = "08db3feb.percona.com"
 
 // CreateRuntimeManager wraps internal/controller/runtime.NewManager and modifies the given options:
 //   - Fully overwrites the Cache field
 //   - Sets Cache.SyncPeriod to refreshInterval const
 //   - Sets Cache.DefaultNamespaces by using k8s.GetWatchNamespace() split by ","
-//   - Sets LeaderElection to true
-//   - Sets LeaderElectionID to the electionID const
 //   - Sets BaseContext to include the provided feature gates
 func CreateRuntimeManager(config *rest.Config, features feature.MutableGate, options manager.Options) (manager.Manager, error) {
 	namespaces, err := k8s.GetWatchNamespace()
@@ -44,9 +42,6 @@ func CreateRuntimeManager(config *rest.Config, features feature.MutableGate, opt
 		}
 		options.Cache.DefaultNamespaces = namespaces
 	}
-
-	options.LeaderElection = true
-	options.LeaderElectionID = electionID
 
 	options.BaseContext = func() context.Context {
 		ctx := context.Background()


### PR DESCRIPTION
[![K8SPG-761](https://badgen.net/badge/JIRA/K8SPG-761/green)](https://jira.percona.com/browse/K8SPG-761) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPG-761

**DESCRIPTION**
---
This PR adds support for the `PGO_WORKERS` environment variable in the operator. It allows to configure the number of concurrent reconciliations for the `postgres-operator.crunchydata.com/v1beta1` `PostgresCluster` resource.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-761]: https://perconadev.atlassian.net/browse/K8SPG-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ