### PR TITLE
K8SPG-719 use image.tag and image.repository to configure pmm3 server on e2e tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ void createCluster(String CLUSTER_SUFFIX) {
                 gcloud auth activate-service-account --key-file $CLIENT_SECRET_FILE
                 gcloud config set project $GCP_PROJECT
                 gcloud container clusters list --filter $CLUSTER_NAME-${CLUSTER_SUFFIX} --zone $region --format='csv[no-heading](name)' | xargs gcloud container clusters delete --zone $region --quiet || true
-                gcloud container clusters create --zone $region $CLUSTER_NAME-${CLUSTER_SUFFIX} --cluster-version=1.29 --machine-type=n1-standard-4 --preemptible --disk-size 30 --num-nodes=\$NODES_NUM --network=jenkins-vpc --subnetwork=jenkins-${CLUSTER_SUFFIX} --no-enable-autoupgrade --cluster-ipv4-cidr=/21 --labels delete-cluster-after-hours=6 --enable-ip-alias && \
+                gcloud container clusters create --zone $region $CLUSTER_NAME-${CLUSTER_SUFFIX} --cluster-version=1.30 --machine-type=n1-standard-4 --preemptible --disk-size 30 --num-nodes=\$NODES_NUM --network=jenkins-vpc --subnetwork=jenkins-${CLUSTER_SUFFIX} --no-enable-autoupgrade --cluster-ipv4-cidr=/21 --labels delete-cluster-after-hours=6 --enable-ip-alias && \
                 kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user jenkins@"$GCP_PROJECT".iam.gserviceaccount.com || ret_val=\$?
                 if [ \${ret_val} -eq 0 ]; then break; fi
                 ret_num=\$((ret_num + 1))

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -395,8 +395,8 @@ deploy_pmm3_server() {
 		helm repo add percona https://percona.github.io/percona-helm-charts/
 		helm install monitoring percona/pmm -n "${NAMESPACE}" \
 			--set fullnameOverride=monitoring \
-			--set image.tag=3-dev-latest \
-			--set image.repository=perconalab/pmm-server \
+			--set image.tag=${IMAGE_PMM3_SERVER#*:} \
+			--set image.repository=${IMAGE_PMM3_SERVER%:*} \
 			--set service.type=LoadBalancer \
 			--set platform="$platform" \
 			--force

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -395,8 +395,8 @@ deploy_pmm3_server() {
 		helm repo add percona https://percona.github.io/percona-helm-charts/
 		helm install monitoring percona/pmm -n "${NAMESPACE}" \
 			--set fullnameOverride=monitoring \
-			--set imageTag=3-dev-latest \
-			--set imageRepo=perconalab/pmm-server \
+			--set image.tag=3-dev-latest \
+			--set image.repository=perconalab/pmm-server \
 			--set service.type=LoadBalancer \
 			--set platform="$platform" \
 			--force

--- a/e2e-tests/release_versions
+++ b/e2e-tests/release_versions
@@ -30,6 +30,8 @@ IMAGE_UPGRADE=percona/percona-postgresql-operator:2.6.0-upgrade
 
 IMAGE_PMM_CLIENT=percona/pmm-client:2.44.0
 IMAGE_PMM_SERVER=percona/pmm-server:2.44.0
+IMAGE_PMM3_CLIENT=percona/pmm-client:3.1.0
+IMAGE_PMM3_SERVER=percona/pmm-server:3.1.0
 
 # Supported k8s versions
 GKE_MIN=1.29

--- a/e2e-tests/tests/monitoring-pmm3/03-create-cluster.yaml
+++ b/e2e-tests/tests/monitoring-pmm3/03-create-cluster.yaml
@@ -10,5 +10,5 @@ commands:
 
       get_cr \
         | yq eval '.spec.pmm.enabled=true' - \
-        | yq eval '.spec.pmm.image="perconalab/pmm-client:3-dev-latest"' - \
+        | yq eval ".spec.pmm.image=\"${IMAGE_PMM3_CLIENT}\"" - \
         | kubectl -n "${NAMESPACE}" apply -f -

--- a/e2e-tests/vars.sh
+++ b/e2e-tests/vars.sh
@@ -23,6 +23,8 @@ export BUCKET=${BUCKET:-"pg-operator-testing"}
 export PMM_SERVER_VERSION=${PMM_SERVER_VERSION:-"9.9.9"}
 export IMAGE_PMM_CLIENT=${IMAGE_PMM_CLIENT:-"perconalab/pmm-client:dev-latest"}
 export IMAGE_PMM_SERVER=${IMAGE_PMM_SERVER:-"perconalab/pmm-server:dev-latest"}
+export IMAGE_PMM3_CLIENT=${IMAGE_PMM3_CLIENT:-"perconalab/pmm-client:3-dev-latest"}
+export IMAGE_PMM3_SERVER=${IMAGE_PMM3_SERVER:-"perconalab/pmm-server:3-dev-latest"}
 export PGOV1_TAG=${PGOV1_TAG:-"1.4.0"}
 export PGOV1_VER=${PGOV1_VER:-"14"}
 


### PR DESCRIPTION
[![K8SPG-719](https://badgen.net/badge/JIRA/K8SPG-719/green)](https://jira.percona.com/browse/K8SPG-719) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
With the image and tag misconfigured, they are ignored, and instead, we are always using by default the latest released version.






**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
based on this: https://github.com/percona/percona-helm-charts/tree/main/charts/pmm#percona-monitoring-and-management-pmm-parameters

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-719]: https://perconadev.atlassian.net/browse/K8SPG-719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ