### PR TITLE
K8SPG-798 introduce retry logic on self-healing test

### DIFF
--- a/e2e-tests/tests/self-healing/07-read-from-all-pods.yaml
+++ b/e2e-tests/tests/self-healing/07-read-from-all-pods.yaml
@@ -3,7 +3,6 @@ kind: TestStep
 timeout: 30
 commands:
     - script: |-
-          set -o errexit
           set -o xtrace
           
           source ../../functions

--- a/e2e-tests/tests/self-healing/10-read-from-all-pods.yaml
+++ b/e2e-tests/tests/self-healing/10-read-from-all-pods.yaml
@@ -3,7 +3,6 @@ kind: TestStep
 timeout: 30
 commands:
     - script: |-
-          set -o errexit
           set -o xtrace
           
           source ../../functions

--- a/e2e-tests/tests/self-healing/13-read-from-all-pods.yaml
+++ b/e2e-tests/tests/self-healing/13-read-from-all-pods.yaml
@@ -3,7 +3,6 @@ kind: TestStep
 timeout: 30
 commands:
     - script: |-
-          set -o errexit
           set -o xtrace
           
           source ../../functions

--- a/e2e-tests/tests/self-healing/16-read-from-all-pods.yaml
+++ b/e2e-tests/tests/self-healing/16-read-from-all-pods.yaml
@@ -3,7 +3,6 @@ kind: TestStep
 timeout: 30
 commands:
     - script: |-
-          set -o errexit
           set -o xtrace
           
           source ../../functions


### PR DESCRIPTION
[![K8SPG-798](https://badgen.net/badge/JIRA/K8SPG-798/green)](https://jira.percona.com/browse/K8SPG-798) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**

The self-healing test is very flaky, especially on this step:

```

er.go:42: 12:55:14 | self-healing/13-read-from-all-pods | +++ get_client_pod
    logger.go:42: 12:55:14 | self-healing/13-read-from-all-pods | +++ kubectl -n kuttl-test-unified-alpaca get pods --selector=name=pg-client -o 'jsonpath={.items[].metadata.name}'
    logger.go:42: 12:55:15 | self-healing/13-read-from-all-pods | ++ kubectl -n kuttl-test-unified-alpaca exec pg-client-84d6c45668-r2qjs -- bash -c 'printf '\''\c myapp \\\ SELECT * from myApp;\n'\'' | psql -v ON_ERROR_STOP=1 -t -q postgres://'\''postgres:wejl1rCytZCXgkUMiJeCAZNO@self-healing-instance1-g8k4-0.self-healing-pods.kuttl-test-unified-alpaca.svc'\'''
    logger.go:42: 12:55:16 | self-healing/13-read-from-all-pods | psql: error: connection to server at "self-healing-instance1-g8k4-0.self-healing-pods.kuttl-test-unified-alpaca.svc" (10.112.208.28), port 5432 failed: No route to host
    logger.go:42: 12:55:16 | self-healing/13-read-from-all-pods | 	Is the server running on that host and accepting TCP/IP connections?
    logger.go:42: 12:55:16 | self-healing/13-read-from-all-pods | command terminated with exit code 2
    logger.go:42: 12:55:16 | self-healing/13-read-from-all-pods | + data=
    case.go:378: failed in step 13-read-from-all-pods
    case.go:380: command "set -o xtrace\\n source ../../functions\\n pods=$(get_instance_set_po..." failed, exit status 2
    logger.go:42: 12:55:16 | self-healing | self-healing events from ns kuttl-test-unified-alpaca:
    logger.go:42: 12:55:16 | self-healing | 2025-06-24 12:50:01 +0000 UTC	Normal	Pod pg-client-84d6c45668-r2qjs	Binding	Scheduled	Successfully assigned kuttl-test-unified-alpaca/pg-client-84d6c45668-r2qjs to gke-jen-pg-1176-cb6df120-default-pool-694ae38a-1q87	default-scheduler	
    logger.go:42: 12:55:16 | self-healing | 2025-06-24 12:50:01 +0000 UTC	Normal	ReplicaSet.apps pg-client-84d6c45668		SuccessfulCreate	Created pod: pg-client-84d6c45668-r2qjs	replicaset-controller	
    logger.go:42: 12:55:16 | self-healing | 2025-06-24 12:50:01 +0000 UTC	Normal	Deployment.apps pg-clie
```

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
We are introducing retry logic on all the read from all pods steps so that we can ensure that if pods are not ready to serve the respective assertions, this will be handled gracefully by the test. 

![Screenshot 2025-06-25 at 10 43 33 AM](https://github.com/user-attachments/assets/1e448c02-3cf0-4c93-8488-97320bc28b1a)


**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-798]: https://perconadev.atlassian.net/browse/K8SPG-798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ