### PR TITLE
K8SPG-613: fix cr.yaml

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -17,24 +17,25 @@ spec:
 #        cpu: 2.0
 #        memory: 4Gi
 #    containerSecurityContext:
-#      fsGroup: 1001
 #      runAsUser: 1001
-#      runAsNonRoot: true
-#      fsGroupChangePolicy: "OnRootMismatch"
 #      runAsGroup: 1001
-#      seLinuxOptions:
-#        type: spc_t
-#        level: s0:c123,c456
+#      runAsNonRoot: true
+#      privileged: false
+#      allowPrivilegeEscalation: false
+#      readOnlyRootFilesystem: true
+#      capabilities:
+#        add:
+#          - NET_ADMIN
+#          - SYS_TIME
+#        drop:
+#          - ALL
 #      seccompProfile:
 #        type: Localhost
 #        localhostProfile: localhost/profile.json
-#      supplementalGroups:
-#      - 1001
-#      sysctls:
-#      - name: net.ipv4.tcp_keepalive_time
-#        value: "600"
-#      - name: net.ipv4.tcp_keepalive_intvl
-#        value: "60"
+#      procMount: Default
+#      seLinuxOptions:
+#        type: spc_t
+#        level: s0:c123,c456
 #  metadata:
 #    annotations:
 #      example-annotation: value
@@ -182,24 +183,25 @@ spec:
 #          cpu: 2.0
 #          memory: 4Gi
 #      containerSecurityContext:
-#        fsGroup: 1001
 #        runAsUser: 1001
-#        runAsNonRoot: true
-#        fsGroupChangePolicy: "OnRootMismatch"
 #        runAsGroup: 1001
-#        seLinuxOptions:
-#          type: spc_t
-#          level: s0:c123,c456
+#        runAsNonRoot: true
+#        privileged: false
+#        allowPrivilegeEscalation: false
+#        readOnlyRootFilesystem: true
+#        capabilities:
+#          add:
+#            - NET_ADMIN
+#            - SYS_TIME
+#          drop:
+#            - ALL
 #        seccompProfile:
 #          type: Localhost
 #          localhostProfile: localhost/profile.json
-#        supplementalGroups:
-#        - 1001
-#        sysctls:
-#        - name: net.ipv4.tcp_keepalive_time
-#          value: "600"
-#        - name: net.ipv4.tcp_keepalive_intvl
-#          value: "60"
+#        procMount: Default
+#        seLinuxOptions:
+#          type: spc_t
+#          level: s0:c123,c456
 
     affinity:
       podAntiAffinity:
@@ -385,24 +387,25 @@ spec:
 #            cpu: 2.0
 #            memory: 4Gi
 #        containerSecurityContext:
-#          fsGroup: 1001
 #          runAsUser: 1001
-#          runAsNonRoot: true
-#          fsGroupChangePolicy: "OnRootMismatch"
 #          runAsGroup: 1001
-#          seLinuxOptions:
-#            type: spc_t
-#            level: s0:c123,c456
+#          runAsNonRoot: true
+#          privileged: false
+#          allowPrivilegeEscalation: false
+#          readOnlyRootFilesystem: true
+#          capabilities:
+#            add:
+#              - NET_ADMIN
+#              - SYS_TIME
+#            drop:
+#              - ALL
 #          seccompProfile:
 #            type: Localhost
 #            localhostProfile: localhost/profile.json
-#          supplementalGroups:
-#          - 1001
-#          sysctls:
-#          - name: net.ipv4.tcp_keepalive_time
-#            value: "600"
-#          - name: net.ipv4.tcp_keepalive_intvl
-#            value: "60"
+#          procMount: Default
+#          seLinuxOptions:
+#            type: spc_t
+#            level: s0:c123,c456
 #      containers:
 #        pgbackrest:
 #          resources:


### PR DESCRIPTION
[![K8SPG-613](https://badgen.net/badge/JIRA/K8SPG-613/green)](https://jira.percona.com/browse/K8SPG-613) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPG-613

**DESCRIPTION**
---
The previous PR (https://github.com/percona/percona-postgresql-operator/pull/1117) introduced an incorrect `containerSecurityContext` that does not match the `crd.yaml`

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-613]: https://perconadev.atlassian.net/browse/K8SPG-613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ