### PR TITLE
K8SPG-730: add `.status.observedGeneration` for PerconaPGCluster

### DIFF
--- a/build/crd/percona/generated/pgv2.percona.com_perconapgclusters.yaml
+++ b/build/crd/percona/generated/pgv2.percona.com_perconapgclusters.yaml
@@ -18345,6 +18345,9 @@ spec:
                 items:
                   type: string
                 type: array
+              observedGeneration:
+                format: int64
+                type: integer
               patroniVersion:
                 type: string
               pgbouncer:

--- a/config/crd/bases/pgv2.percona.com_perconapgclusters.yaml
+++ b/config/crd/bases/pgv2.percona.com_perconapgclusters.yaml
@@ -18752,6 +18752,9 @@ spec:
                 items:
                   type: string
                 type: array
+              observedGeneration:
+                format: int64
+                type: integer
               patroniVersion:
                 type: string
               pgbouncer:

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -19049,6 +19049,9 @@ spec:
                 items:
                   type: string
                 type: array
+              observedGeneration:
+                format: int64
+                type: integer
               patroniVersion:
                 type: string
               pgbouncer:

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -19049,6 +19049,9 @@ spec:
                 items:
                   type: string
                 type: array
+              observedGeneration:
+                format: int64
+                type: integer
               patroniVersion:
                 type: string
               pgbouncer:

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -19049,6 +19049,9 @@ spec:
                 items:
                   type: string
                 type: array
+              observedGeneration:
+                format: int64
+                type: integer
               patroniVersion:
                 type: string
               pgbouncer:

--- a/percona/controller/pgcluster/status.go
+++ b/percona/controller/pgcluster/status.go
@@ -122,6 +122,8 @@ func (r *PGClusterReconciler) updateStatus(ctx context.Context, cr *v2.PerconaPG
 
 		cluster.Status.State = r.getState(cr, &cluster.Status, status)
 
+		cluster.Status.ObservedGeneration = cluster.Generation
+
 		updateConditions(cluster, status)
 
 		return r.Client.Status().Update(ctx, cluster)

--- a/percona/controller/pgcluster/status_test.go
+++ b/percona/controller/pgcluster/status_test.go
@@ -93,6 +93,7 @@ var _ = Describe("PG Cluster status", Ordered, func() {
 			Expect(cr.Status.Postgres.Ready).Should(Equal(int32(3)))
 			Expect(cr.Status.Postgres.Size).Should(Equal(int32(4)))
 			Expect(cr.Status.Postgres.InstanceSets).Should(HaveLen(2))
+			Expect(cr.Status.ObservedGeneration).Should(Equal(int64(1)))
 			Expect(cr.Status.Postgres.InstanceSets).Should(ContainElement(gs.MatchFields(gs.IgnoreExtras, gs.Fields{
 				"Name":  Equal("instance1"),
 				"Ready": Equal(int32(0)),
@@ -138,6 +139,7 @@ var _ = Describe("PG Cluster status", Ordered, func() {
 				return err == nil
 			}, time.Second*15, time.Millisecond*250).Should(BeTrue())
 
+			Expect(cr.Status.ObservedGeneration).Should(Equal(int64(1)))
 			Expect(cr.Status.PGBouncer.Ready).Should(Equal(int32(0)))
 			Expect(cr.Status.PGBouncer.Size).Should(Equal(int32(1)))
 		})
@@ -294,6 +296,7 @@ var _ = Describe("PG Cluster status", Ordered, func() {
 					return err == nil
 				}, time.Second*15, time.Millisecond*250).Should(BeTrue())
 				Expect(cr.Status.Host).Should(Equal(pgBouncerSVC.Name + "." + ns + ".svc"))
+				Expect(cr.Status.ObservedGeneration).Should(Equal(int64(2)))
 			})
 		})
 
@@ -330,6 +333,8 @@ var _ = Describe("PG Cluster status", Ordered, func() {
 					return err == nil
 				}, time.Second*15, time.Millisecond*250).Should(BeTrue())
 				Expect(cr.Status.Host).Should(Equal("22.22.22.22"))
+
+				Expect(cr.Status.ObservedGeneration).Should(Equal(int64(3)))
 			})
 		})
 	})
@@ -393,6 +398,7 @@ var _ = Describe("PG Cluster status", Ordered, func() {
 
 				condition := meta.FindStatusCondition(cr.Status.Conditions, pNaming.ConditionClusterIsReadyForBackup)
 				Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
+				Expect(cr.Status.ObservedGeneration).Should(Equal(int64(1)))
 			})
 		})
 

--- a/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
+++ b/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
@@ -457,6 +457,10 @@ type PerconaPGClusterStatus struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=status
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 type Backups struct {
@@ -823,7 +827,8 @@ func (p PGInstanceSetSpec) ToCrunchy() crunchyv1beta1.PostgresInstanceSetSpec {
 		VolumeMounts:              p.VolumeMounts,
 		SecurityContext:           p.SecurityContext,
 		TablespaceVolumes:         p.TablespaceVolumes,
-		InitContainer:             p.InitContainer}
+		InitContainer:             p.InitContainer,
+	}
 }
 
 type ServiceExpose struct {


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/K8SPG-730

**DESCRIPTION**
---
This PR adds `.status.observedGeneration` for `PerconaPGCluster` resource

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
