### PR TITLE
K8SPG-781 add original error

### DIFF
--- a/percona/watcher/wal.go
+++ b/percona/watcher/wal.go
@@ -3,6 +3,7 @@ package watcher
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -167,6 +168,7 @@ func GetLatestCommitTimestamp(ctx context.Context, cli client.Client, execCli *c
 
 	primary, err := perconaPG.GetPrimaryPod(ctx, cli, cr)
 	if err != nil {
+		log.V(1).Info("failed to get primary pod", "err", err)
 		return nil, PrimaryPodNotFound
 	}
 
@@ -203,7 +205,7 @@ func GetLatestCommitTimestamp(ctx context.Context, cli client.Client, execCli *c
 func getBackupStartTimestamp(ctx context.Context, cli client.Client, cr *pgv2.PerconaPGCluster, backup *pgv2.PerconaPGBackup) (time.Time, error) {
 	primary, err := perconaPG.GetPrimaryPod(ctx, cli, cr)
 	if err != nil {
-		return time.Time{}, PrimaryPodNotFound
+		return time.Time{}, fmt.Errorf("%w: %v", PrimaryPodNotFound, err)
 	}
 
 	pgbackrestInfo, err := pgbackrest.GetInfo(ctx, primary, backup.Spec.RepoName)

--- a/percona/watcher/wal.go
+++ b/percona/watcher/wal.go
@@ -168,7 +168,7 @@ func GetLatestCommitTimestamp(ctx context.Context, cli client.Client, execCli *c
 
 	primary, err := perconaPG.GetPrimaryPod(ctx, cli, cr)
 	if err != nil {
-		log.V(1).Info("failed to get primary pod", "err", err)
+		log.Error(err, "failed to get primary pod")
 		return nil, PrimaryPodNotFound
 	}
 


### PR DESCRIPTION
[![K8SPG-781](https://badgen.net/badge/JIRA/K8SPG-781/green)](https://jira.percona.com/browse/K8SPG-781) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
We do not return original error if primary not found. 

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
For method `getBackupStartTimestamp` the error message was updated with err message. 
For `GetLatestCommitTimestamp` log was added, since we use this error message in switch statement:
```
switch {
				case errors.Is(err, PrimaryPodNotFound) && localCr.Status.State != pgv2.AppStateReady:
					log.V(1).Info("Primary pod not found, skipping WAL watcher")
				case errors.Is(err, LatestTimestampFileNotFound):
					log.V(1).Info("Latest commit timestamp file not found", "file", LatestCommitTimestampFile)
				case errors.Is(err, LatestTimestampIsBeforeBackupStart):
					log.V(1).Info("Latest commit timestamp is before backup start timestamp")
				default:
					log.Error(err, "get latest commit timestamp")
				}
```

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?