### PR TITLE
Release 2.7.0 op

### DIFF
--- a/e2e-tests/vars.sh
+++ b/e2e-tests/vars.sh
@@ -34,16 +34,6 @@ export IMAGE_PMM3_SERVER=${IMAGE_PMM3_SERVER:-"perconalab/pmm-server:3-dev-lates
 export PGOV1_TAG=${PGOV1_TAG:-"1.4.0"}
 export PGOV1_VER=${PGOV1_VER:-"14"}
 
-# if [[ $OPENSHIFT ]]; then
-# 	REGISTRY='docker.io/'
-# 	echo "Append 'docker.io to images for openshift'"
-# 	for var in $(printenv | grep IMAGE | awk -F'=' '{print $1}'); do
-# 		echo "Reassigning vars"
-# 		var_value=$(eval "echo \$$var")
-# 		eval "$var='$REGISTRY$var_value'"
-# 	done
-# fi
-
 if [[ $OPENSHIFT ]]; then
   REGISTRY='docker.io/'
   echo "Appending 'docker.io/' to image variables for OpenShift..."
@@ -55,8 +45,6 @@ if [[ $OPENSHIFT ]]; then
     echo "$var=$new_value"
   done
 fi
-
-echo $IMAGE_BASE $IMAGE $IMAGE_PGBOUNCER $IMAGE_BACKREST $IMAGE_PMM_CLIENT $IMAGE_PMM_SERVER $IMAGE_PMM3_CLIENT $IMAGE_PMM3_CLIENT $IMAGE_PMM3_SERVER
 
 # shellcheck disable=SC2034
 date=$(which gdate || which date)

--- a/e2e-tests/vars.sh
+++ b/e2e-tests/vars.sh
@@ -18,8 +18,6 @@ if command -v oc &>/dev/null; then
 	fi
 fi
 
-OPENSHIFT=4
-
 export IMAGE_BASE=${IMAGE_BASE:-"perconalab/percona-postgresql-operator"}
 export IMAGE=${IMAGE:-"${IMAGE_BASE}:${VERSION}"}
 export PG_VER="${PG_VER:-17}"


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
Openshift does not fallback to `docker.io` repository any more if not full image name is provided. 

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
Add `docker.io` in openshift tests for our images.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
