### PR TITLE
Extend test to verify CA update

### DIFF
--- a/e2e-tests/tests/custom-tls/06-assert.yaml
+++ b/e2e-tests/tests/custom-tls/06-assert.yaml
@@ -1,0 +1,45 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 100
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: new-custom-cert-tls-pg-ca-issuer
+spec:
+  selfSigned: {}
+status:
+  conditions:
+  - observedGeneration: 1
+    reason: IsReady
+    status: "True"
+    type: Ready
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  generation: 1
+  name: new-custom-cert-tls-pg-ca-cert
+spec:
+  commonName: new-postgres-operator-ca
+  duration: 26280h0m0s
+  isCA: true
+  issuerRef:
+    kind: Issuer
+    name: new-custom-cert-tls-pg-ca-issuer
+  renewBefore: 730h0m0s
+  secretName: new-custom-cert-tls-pg-ca-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 384
+  usages:
+  - cert sign
+  - crl sign
+status:
+  conditions:
+  - message: Certificate is up to date and has not expired
+    observedGeneration: 1
+    reason: Ready
+    status: "True"
+    type: Ready
+  revision: 1

--- a/e2e-tests/tests/custom-tls/06-create-new-ca.yaml
+++ b/e2e-tests/tests/custom-tls/06-create-new-ca.yaml
@@ -1,0 +1,26 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: new-custom-cert-tls-pg-ca-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: new-custom-cert-tls-pg-ca-cert
+spec:
+  isCA: true
+  commonName: new-postgres-operator-ca
+  secretName: new-custom-cert-tls-pg-ca-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 384
+  issuerRef:
+    name: new-custom-cert-tls-pg-ca-issuer
+    kind: Issuer
+  duration: 26280h0m0s
+  renewBefore: 730h0m0s
+  usages:
+    - "cert sign"
+    - "crl sign"

--- a/e2e-tests/tests/custom-tls/07-assert.yaml
+++ b/e2e-tests/tests/custom-tls/07-assert.yaml
@@ -1,0 +1,90 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 100
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  generation: 1
+  name: new-custom-cert-tls-pg-issuer
+spec:
+  ca:
+    secretName: new-custom-cert-tls-pg-ca-cert
+status:
+  conditions:
+  - message: Signing CA verified
+    observedGeneration: 1
+    reason: KeyPairVerified
+    status: "True"
+    type: Ready
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  generation: 1
+  name: new-custom-cert-tls-ssl
+spec:
+  commonName: new-custom-tls-primary
+  issuerRef:
+    kind: Issuer
+    name: new-custom-cert-tls-pg-issuer
+  secretName: new-custom-cert-tls-ssl
+status:
+  conditions:
+  - message: Certificate is up to date and has not expired
+    observedGeneration: 1
+    reason: Ready
+    status: "True"
+    type: Ready
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  generation: 1
+  name: new-custom-cert-tls-ssl-replica
+spec:
+  commonName: _crunchyrepl
+  issuerRef:
+    kind: Issuer
+    name: new-custom-cert-tls-pg-issuer
+  secretName: new-custom-cert-tls-ssl-replica
+status:
+  conditions:
+  - message: Certificate is up to date and has not expired
+    observedGeneration: 1
+    reason: Ready
+    status: "True"
+    type: Ready
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    cert-manager.io/alt-names: ""
+    cert-manager.io/certificate-name: new-custom-cert-tls-pg-ca-cert
+    cert-manager.io/common-name: new-postgres-operator-ca
+    cert-manager.io/ip-sans: ""
+    cert-manager.io/issuer-group: ""
+    cert-manager.io/issuer-kind: Issuer
+    cert-manager.io/issuer-name: new-custom-cert-tls-pg-ca-issuer
+    cert-manager.io/uri-sans: ""
+  labels:
+    controller.cert-manager.io/fao: "true"
+  name: new-custom-cert-tls-pg-ca-cert
+type: kubernetes.io/tls
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    controller.cert-manager.io/fao: "true"
+  name: new-custom-cert-tls-ssl
+type: kubernetes.io/tls
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    controller.cert-manager.io/fao: "true"
+  name: new-custom-cert-tls-ssl-replica
+type: kubernetes.io/tls

--- a/e2e-tests/tests/custom-tls/07-create-new-certs.yaml
+++ b/e2e-tests/tests/custom-tls/07-create-new-certs.yaml
@@ -1,0 +1,51 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: new-custom-cert-tls-pg-issuer
+spec:
+  ca:
+    secretName: new-custom-cert-tls-pg-ca-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  generation: 1
+  name: new-custom-cert-tls-ssl
+spec:
+  commonName: new-custom-tls-primary
+  dnsNames:
+  - new-custom-tls-primary.$NAMESPACE.svc.cluster.local
+  - new-custom-tls-primary.$NAMESPACE.svc
+  - new-custom-tls-primary.$NAMESPACE
+  - new-custom-tls-primary
+  - new-custom-tls-replicas.$NAMESPACE.svc.cluster.local
+  - new-custom-tls-replicas.$NAMESPACE.svc
+  - new-custom-tls-replicas.$NAMESPACE
+  - new-custom-tls-replicas
+  issuerRef:
+    kind: Issuer
+    name: new-custom-cert-tls-pg-issuer
+  secretName: new-custom-cert-tls-ssl
+  privateKey:
+    algorithm: ECDSA
+    size: 384
+  usages:
+    - "digital signature"
+    - "key encipherment"
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: new-custom-cert-tls-ssl-replica
+spec:
+  commonName: _crunchyrepl
+  issuerRef:
+    kind: Issuer
+    name: new-custom-cert-tls-pg-issuer
+  secretName: new-custom-cert-tls-ssl-replica
+  privateKey:
+    algorithm: ECDSA
+    size: 384
+  usages:
+    - "digital signature"
+    - "key encipherment"

--- a/e2e-tests/tests/custom-tls/08-assert.yaml
+++ b/e2e-tests/tests/custom-tls/08-assert.yaml
@@ -1,0 +1,89 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  labels:
+    postgres-operator.crunchydata.com/cluster: custom-tls
+    postgres-operator.crunchydata.com/data: postgres
+    postgres-operator.crunchydata.com/instance-set: instance1
+  ownerReferences:
+    - apiVersion: postgres-operator.crunchydata.com/v1beta1
+      kind: PostgresCluster
+      name: custom-tls
+      controller: true
+      blockOwnerDeletion: true
+status:
+  observedGeneration: 2
+  replicas: 1
+  readyReplicas: 1
+  updatedReplicas: 1
+  collisionCount: 0
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: custom-tls-pgbouncer
+  labels:
+    postgres-operator.crunchydata.com/cluster: custom-tls
+    postgres-operator.crunchydata.com/role: pgbouncer
+  annotations:
+    deployment.kubernetes.io/revision: '2'
+  ownerReferences:
+    - apiVersion: postgres-operator.crunchydata.com/v1beta1
+      kind: PostgresCluster
+      name: custom-tls
+      controller: true
+      blockOwnerDeletion: true
+status:
+  observedGeneration: 2
+  replicas: 3
+  updatedReplicas: 3
+  readyReplicas: 3
+---
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: custom-tls
+  ownerReferences:
+    - apiVersion: pgv2.percona.com/v2
+      kind: PerconaPGCluster
+      name: custom-tls
+      controller: true
+      blockOwnerDeletion: true
+  finalizers:
+    - postgres-operator.crunchydata.com/finalizer
+status:
+  instances:
+    - name: instance1
+      readyReplicas: 3
+      replicas: 3
+      updatedReplicas: 3
+  observedGeneration: 2
+  pgbackrest:
+    repos:
+      - name: repo1
+        stanzaCreated: true
+  proxy:
+    pgBouncer:
+      readyReplicas: 3
+      replicas: 3
+---
+apiVersion: pgv2.percona.com/v2
+kind: PerconaPGCluster
+metadata:
+  name: custom-tls
+status:
+  pgbouncer:
+    ready: 3
+    size: 3
+  postgres:
+    instances:
+    - name: instance1
+      ready: 3
+      size: 3
+    ready: 3
+    size: 3
+  state: ready

--- a/e2e-tests/tests/custom-tls/08-upgrade-cluster.yaml
+++ b/e2e-tests/tests/custom-tls/08-upgrade-cluster.yaml
@@ -1,0 +1,20 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 10
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      get_cr "custom-tls" ${RANDOM} \
+        | yq '.spec.secrets.customRootCATLSSecret.name="new-custom-cert-tls-pg-ca-cert"' \
+        | yq '.spec.secrets.customRootCATLSSecret.items[0].key="tls.key"' \
+        | yq '.spec.secrets.customRootCATLSSecret.items[0].path="root.key"' \
+        | yq '.spec.secrets.customRootCATLSSecret.items[1].key="tls.crt"' \
+        | yq '.spec.secrets.customRootCATLSSecret.items[1].path="root.crt"' \
+        | yq '.spec.secrets.customTLSSecret.name="new-custom-cert-tls-ssl"' \
+        | yq '.spec.secrets.customReplicationTLSSecret.name="new-custom-cert-tls-ssl-replica"' \
+        | kubectl -n "${NAMESPACE}" apply -f -
+      

--- a/e2e-tests/tests/custom-tls/09-verify-certs-update.yaml
+++ b/e2e-tests/tests/custom-tls/09-verify-certs-update.yaml
@@ -1,0 +1,18 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 30
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      pg_certificate_data=$(run_command_local "openssl s_client -connect custom-tls-primary:5432 -starttls postgres <<< '' | openssl x509 -noout -subject -issuer -dates -serial")
+
+      if [[ "$pg_certificate_data" != *"subject=CN=new-custom-tls-primary"* || "$pg_certificate_data" != *"issuer=CN=new-postgres-operator-ca"* ]]; then
+          echo "Postgres not configured with the new certificate"
+          exit 1
+      fi
+
+      

--- a/e2e-tests/tests/custom-tls/10-write-data.yaml
+++ b/e2e-tests/tests/custom-tls/10-write-data.yaml
@@ -1,0 +1,17 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 30
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      run_psql_local \
+        'CREATE DATABASE newapp; \c newapp \\\ CREATE TABLE IF NOT EXISTS newApp (id int PRIMARY KEY);' \
+        "postgres:$(get_psql_user_pass custom-tls-pguser-postgres)@$(get_psql_user_host custom-tls-pguser-postgres)"
+      
+      run_psql_local \
+        '\c newapp \\\ INSERT INTO newApp (id) VALUES (100600)' \
+        "postgres:$(get_psql_user_pass custom-tls-pguser-postgres)@$(get_psql_user_host custom-tls-pguser-postgres)"

--- a/e2e-tests/tests/custom-tls/11-verify-data-written-in-primary.yaml
+++ b/e2e-tests/tests/custom-tls/11-verify-data-written-in-primary.yaml
@@ -1,0 +1,17 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 30
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      data=$(run_psql_local '\c newapp \\\ SELECT * from newApp;' "postgres:$(get_psql_user_pass custom-tls-pguser-postgres)@$(get_psql_user_host custom-tls-pguser-postgres)")
+
+      if [[ "$data" != *"100600"* ]]; then
+          echo "Missing data in primary"
+          exit 1
+      fi
+


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
Extend custom-tls test to verify CA update

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
