### PR TITLE
K8SPG-826 use /tmp/pmm for pmm3 env var PMM_AGENT_PATHS_TEMPDIR

### DIFF
--- a/percona/pmm/pmm.go
+++ b/percona/pmm/pmm.go
@@ -411,7 +411,7 @@ func sidecarContainerV3(pgc *v2.PerconaPGCluster) corev1.Container {
 			},
 			{
 				Name:  "PMM_AGENT_PATHS_TEMPDIR",
-				Value: "/tmp",
+				Value: "/tmp/pmm",
 			},
 		},
 	}

--- a/percona/pmm/pmm_test.go
+++ b/percona/pmm/pmm_test.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/percona/percona-postgresql-operator/percona/version"
 	v2 "github.com/percona/percona-postgresql-operator/pkg/apis/pgv2.percona.com/v2"
 )
 
@@ -26,7 +27,7 @@ func TestContainer(t *testing.T) {
 
 	pgc := &v2.PerconaPGCluster{
 		Spec: v2.PerconaPGClusterSpec{
-			CRVersion: "2.6.0",
+			CRVersion: version.Version(),
 			PMM:       pmmSpec,
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -152,7 +153,7 @@ func TestSidecarContainerV2(t *testing.T) {
 
 	pgc := &v2.PerconaPGCluster{
 		Spec: v2.PerconaPGClusterSpec{
-			CRVersion: "2.7.0",
+			CRVersion: version.Version(),
 			PMM:       pmmSpec,
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -264,7 +265,7 @@ func TestSidecarContainerV3(t *testing.T) {
 
 	pgc := &v2.PerconaPGCluster{
 		Spec: v2.PerconaPGClusterSpec{
-			CRVersion: "2.7.0",
+			CRVersion: version.Version(),
 			PMM:       pmmSpec,
 		},
 		ObjectMeta: metav1.ObjectMeta{
@@ -321,7 +322,7 @@ func TestSidecarContainerV3(t *testing.T) {
 		"DB_USER":                       v2.UserMonitoring,
 		"DB_PASS":                       "", // secret reference is asserted separately
 		"PMM_AGENT_PRERUN_SCRIPT":       "pmm-admin status --wait=10s; pmm-admin add postgresql --username=$(DB_USER) --password='$(DB_PASS)' --host=127.0.0.1 --port=5432 --tls-cert-file=/pgconf/tls/tls.crt --tls-key-file=/pgconf/tls/tls.key --tls-ca-file=/pgconf/tls/ca.crt --tls-skip-verify --skip-connection-check --metrics-mode=push --service-name=$(PMM_AGENT_SETUP_NODE_NAME) --query-source= --cluster=test-cluster --environment=dev-postgres; pmm-admin annotate --service-name=$(PMM_AGENT_SETUP_NODE_NAME) 'Service restarted'",
-		"PMM_AGENT_PATHS_TEMPDIR":       "/tmp",
+		"PMM_AGENT_PATHS_TEMPDIR":       "/tmp/pmm",
 	}
 
 	for _, envVar := range container.Env {


### PR DESCRIPTION
[![K8SPG-826](https://badgen.net/badge/JIRA/K8SPG-826/green)](https://jira.percona.com/browse/K8SPG-826) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**

The pmm-client container on PMM3 uses the /tmp directory, but on OpenShift, this directory will be overwritten by PMM3 when pods restart, leading to potential data loss or issues with metric collection.

This PR updates the configuration to use a different temporary directory for pmm-client regardless of platform, ensuring data safety across pod restarts.

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-826]: https://perconadev.atlassian.net/browse/K8SPG-826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ