### PR TITLE
WIP: set affinity for `patroni-version-check` pod

### DIFF
--- a/percona/controller/pgcluster/controller.go
+++ b/percona/controller/pgcluster/controller.go
@@ -440,6 +440,7 @@ func (r *PGClusterReconciler) reconcilePatroniVersionCheck(ctx context.Context, 
 					},
 				},
 				SecurityContext:               cr.Spec.InstanceSets[0].SecurityContext,
+				Affinity:                      cr.Spec.InstanceSets[0].Affinity,
 				TerminationGracePeriodSeconds: ptr.To(int64(5)),
 				ImagePullSecrets:              cr.Spec.ImagePullSecrets,
 				Resources: &corev1.ResourceRequirements{

--- a/percona/controller/pgcluster/controller_test.go
+++ b/percona/controller/pgcluster/controller_test.go
@@ -1613,6 +1613,15 @@ var _ = Describe("patroni version check", Ordered, func() {
 			cr2.Spec.InstanceSets[0].SecurityContext = &corev1.PodSecurityContext{
 				RunAsUser: &uid,
 			}
+			cr2.Spec.InstanceSets[0].Affinity = &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+						{
+							Weight: int32(1),
+						},
+					},
+				},
+			}
 			cr2.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 				{Name: "test-pull-secret"},
 			}
@@ -1683,10 +1692,20 @@ var _ = Describe("patroni version check", Ordered, func() {
 			expectedImagePullSecrets := []corev1.LocalObjectReference{
 				{Name: "test-pull-secret"},
 			}
+			expectedAffinity := &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+						{
+							Weight: int32(1),
+						},
+					},
+				},
+			}
 
 			Expect(pod.Spec.SecurityContext).To(Equal(expectedSecurityContext))
 			Expect(pod.Spec.TerminationGracePeriodSeconds).To(Equal(ptr.To(int64(5))))
 			Expect(pod.Spec.ImagePullSecrets).To(Equal(expectedImagePullSecrets))
+			Expect(pod.Spec.Affinity).To(Equal(expectedAffinity))
 		})
 
 		It("should preserve existing patroni version in annotation", func() {


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
