### PR TITLE
K8SPG-718: Fix timeout in monitoring-pmm3

### DIFF
--- a/e2e-tests/tests/monitoring-pmm3/04-update-pmm-server-token.yaml
+++ b/e2e-tests/tests/monitoring-pmm3/04-update-pmm-server-token.yaml
@@ -1,13 +1,13 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 60
 commands:
-  - script: |-
+  - timeout: 60
+    script: |-
       set -o errexit
       set -o xtrace
 
       source ../../functions
-      
+
       sts=$(kubectl -n "${NAMESPACE}" get sts --selector=postgres-operator.crunchydata.com/instance-set=instance1 -o jsonpath='{.items[*].metadata.name}')
       for st in $sts; do
         wait_for_generation "sts/$st" 2
@@ -17,9 +17,9 @@ commands:
       [[ -n ${token} && ${token} != null ]] \
         &&  kubectl -n ${NAMESPACE} patch secret monitoring-pmm3-pmm-secret --type merge --patch '{"stringData": {"PMM_SERVER_TOKEN": "'${token}'"}}' \
         || true
-      
+
       sleep 10
-      
+
       sts=$(kubectl -n "${NAMESPACE}" get sts --selector=postgres-operator.crunchydata.com/instance-set=instance1 -o jsonpath='{.items[*].metadata.name}')
       for st in $sts; do
         wait_for_generation "sts/$st" 3


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
Timeout was configured wrong and the test was failing all the time for that reason. 

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
