### PR TITLE
K8SPG-570 treat user-created secrets with operator default secret name as custom

### DIFF
--- a/internal/controller/postgrescluster/postgres.go
+++ b/internal/controller/postgrescluster/postgres.go
@@ -501,10 +501,8 @@ func (r *Reconciler) reconcilePostgresUserSecrets(
 	// with the right labels so that the selector called next to track them
 	// and utilize their data.
 	for _, user := range specUsers {
-		if user.SecretName != "" {
-			if err := r.updateCustomSecretLabels(ctx, cluster, user); err != nil {
-				return specUsers, nil, err
-			}
+		if err := r.updateCustomSecretLabels(ctx, cluster, user); err != nil {
+			return specUsers, nil, err
 		}
 	}
 
@@ -603,8 +601,12 @@ func (r *Reconciler) reconcilePostgresUserSecrets(
 func (r *Reconciler) updateCustomSecretLabels(
 	ctx context.Context, cluster *v1beta1.PostgresCluster, user v1beta1.PostgresUserSpec,
 ) error {
-	secretName := string(user.SecretName)
+
 	userName := string(user.Name)
+	secretName := naming.PostgresUserSecret(cluster, userName).Name
+	if user.SecretName != "" {
+		secretName = string(user.SecretName)
+	}
 
 	secret := &corev1.Secret{}
 	err := r.Client.Get(ctx, types.NamespacedName{


### PR DESCRIPTION
[![K8SPG-570](https://badgen.net/badge/JIRA/K8SPG-570/green)](https://jira.percona.com/browse/K8SPG-570) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
If a `secretName` is not specified when configuring a user through cr but a secret with a valid user password is created for that user using the default secret name that the operator is using for creating secrets itself, the secret should be identified as existing and honor the password that it configures.

e.g.

for secret name `<cluster>-pguser-<username>`, after applying the CR, the existing password of the secret should be honored instead of the operator overwriting it.

For secret created with the following config:
```
apiVersion: v1
kind: Secret
metadata:
  name: cluster1-pguser-rhino
type: Opaque
data:
  password: LixJPlFGWG84djtRdnJMey5qNS0wdnFy
```

The operator updates it with:

```
apiVersion: v1
data:
  dbname: em9v
  host: Y2x1c3RlcjEtcHJpbWFyeS5rZWNoMS5zdmM=
  jdbc-uri: amRiYzpwb3N0Z3Jlc3FsOi8vY2x1c3RlcjEtcHJpbWFyeS5rZWNoMS5zdmM6NTQzMi96b28/cGFzc3dvcmQ9LiUyQ0klM0VRRlhvOHYlM0JRdnJMJTdCLmo1LTB2cXImdXNlcj1yaGlubw==
  password: LixJPlFGWG84djtRdnJMey5qNS0wdnFy
  pgbouncer-host: Y2x1c3RlcjEtcGdib3VuY2VyLmtlY2gxLnN2Yw==
  pgbouncer-jdbc-uri: amRiYzpwb3N0Z3Jlc3FsOi8vY2x1c3RlcjEtcGdib3VuY2VyLmtlY2gxLnN2Yzo1NDMyL3pvbz9wYXNzd29yZD0uJTJDSSUzRVFGWG84diUzQlF2ckwlN0IuajUtMHZxciZwcmVwYXJlVGhyZXNob2xkPTAmdXNlcj1yaGlubw==
  pgbouncer-port: NTQzMg==
  pgbouncer-uri: cG9zdGdyZXNxbDovL3JoaW5vOi4sSSUzRVFGWG84djtRdnJMJTdCLmo1LTB2cXJAY2x1c3RlcjEtcGdib3VuY2VyLmtlY2gxLnN2Yzo1NDMyL3pvbw==
  port: NTQzMg==
  uri: cG9zdGdyZXNxbDovL3JoaW5vOi4sSSUzRVFGWG84djtRdnJMJTdCLmo1LTB2cXJAY2x1c3RlcjEtcHJpbWFyeS5rZWNoMS5zdmM6NTQzMi96b28=
  user: cmhpbm8=
  verifier: U0NSQU0tU0hBLTI1NiQ0MDk2Omk4QmoxN0NIOWFzSVNHNXhBMDhZbmc9PSRxRjViQUVnSW9obmsxSDVQcEV4QmRyVjY2b05xWTBKQjY0Mk1mTjJHdTQwPTo4VnFCZ1R1V1RocVFROUlqeWkxb3N3N2hlKzE1a0xlSFdNNUJIMlhlZGg4PQ==
kind: Secret
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","data":{"password":"LixJPlFGWG84djtRdnJMey5qNS0wdnFy"},"kind":"Secret","metadata":{"annotations":{},"name":"cluster1-pguser-rhino","namespace":"kech1"},"type":"Opaque"}
  creationTimestamp: "2025-09-24T10:22:32Z"
  labels:
    app.kubernetes.io/instance: cluster1
    app.kubernetes.io/managed-by: percona-postgresql-operator
    app.kubernetes.io/name: percona-postgresql
    app.kubernetes.io/part-of: percona-postgresql
    postgres-operator.crunchydata.com/cluster: cluster1
    postgres-operator.crunchydata.com/pguser: rhino
    postgres-operator.crunchydata.com/role: pguser
  name: cluster1-pguser-rhino
  namespace: kech1
  resourceVersion: "1758709579704943009"
  uid: 941cf6aa-b961-4503-a988-74e1fdc701b8
type: Opaque
```

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-570]: https://perconadev.atlassian.net/browse/K8SPG-570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ