### PR TITLE
K8SPG-719 patch pg/monitoring-pmm3 instead of perconapgcluster

### DIFF
--- a/e2e-tests/tests/monitoring-pmm3/06-check-pgstatstatements-query-source.yaml
+++ b/e2e-tests/tests/monitoring-pmm3/06-check-pgstatstatements-query-source.yaml
@@ -7,7 +7,7 @@ commands:
 
       source ../../functions
 
-      kubectl -n ${NAMESPACE} patch perconapgcluster/monitoring-pmm3 --type=merge -p '{
+      kubectl -n ${NAMESPACE} patch pg/monitoring-pmm3 --type=merge -p '{
         "spec":{
           "pmm":{"querySource":"pgstatstatements"},
           "extensions": {"builtin": {"pg_stat_statements": true }}}


### PR DESCRIPTION
[![K8SPG-719](https://badgen.net/badge/JIRA/K8SPG-719/green)](https://jira.percona.com/browse/K8SPG-719) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-719]: https://perconadev.atlassian.net/browse/K8SPG-719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ