### PR TITLE
K8SPG-781 add TestGetLatestCommitTimestamp

### DIFF
--- a/percona/watcher/wal.go
+++ b/percona/watcher/wal.go
@@ -162,6 +162,7 @@ func getLatestBackup(ctx context.Context, cli client.Client, cr *pgv2.PerconaPGC
 	return latest, nil
 }
 
+// GetLatestCommitTimestamp gets the timestamp of the latest commit.
 func GetLatestCommitTimestamp(ctx context.Context, cli client.Client, execCli *clientcmd.Client, cr *pgv2.PerconaPGCluster, backup *pgv2.PerconaPGBackup) (*metav1.Time, error) {
 	log := logging.FromContext(ctx)
 

--- a/percona/watcher/wal_test.go
+++ b/percona/watcher/wal_test.go
@@ -2,6 +2,7 @@ package watcher
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -307,6 +308,52 @@ func TestGetLatestBackup(t *testing.T) {
 				assert.NotNil(t, latest)
 				assert.Equal(t, latest.Name, tt.latestBackupName)
 			}
+		})
+	}
+}
+
+func TestGetLatestCommitTimestamp(t *testing.T) {
+	ctx := context.Background()
+
+	tests := map[string]struct {
+		pods        []client.Object
+		backup      *pgv2.PerconaPGBackup
+		cluster     *pgv2.PerconaPGCluster
+		expectedErr error
+	}{
+		"primary pod not found due to invalid patroni version": {
+			pods: []client.Object{},
+			backup: &pgv2.PerconaPGBackup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "backup1",
+					Namespace: "test-ns",
+				},
+				Spec: pgv2.PerconaPGBackupSpec{
+					PGCluster: "test-cluster",
+					RepoName:  "repo1",
+				},
+			},
+			cluster: &pgv2.PerconaPGCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+				},
+				Status: pgv2.PerconaPGClusterStatus{
+					Patroni: pgv2.Patroni{
+						Version: "error",
+					},
+				},
+			},
+			expectedErr: errors.New("failed to get patroni version: Malformed version: error: primary pod not found"),
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := testutils.BuildFakeClient(tt.pods...)
+
+			_, err := GetLatestCommitTimestamp(ctx, c, nil, tt.cluster, tt.backup)
+
+			assert.EqualError(t, err, tt.expectedErr.Error())
 		})
 	}
 }


### PR DESCRIPTION
[![K8SPG-781](https://badgen.net/badge/JIRA/K8SPG-781/green)](https://jira.percona.com/browse/K8SPG-781) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Adding a small unit test to ensure that the error message contains the additional information.

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-781]: https://perconadev.atlassian.net/browse/K8SPG-781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ