### PR TITLE
K8SPG-883 support cr.Status.PatroniVersion and cr.Status.Patroni.Version

### DIFF
--- a/build/crd/percona/generated/pgv2.percona.com_perconapgclusters.yaml
+++ b/build/crd/percona/generated/pgv2.percona.com_perconapgclusters.yaml
@@ -21143,6 +21143,10 @@ spec:
                   version:
                     type: string
                 type: object
+              patroniVersion:
+                description: 'Deprecated: Use Patroni instead. This field will be
+                  removed in a future release.'
+                type: string
               pgbackrest:
                 description: Status information for pgBackRest
                 properties:

--- a/config/crd/bases/pgv2.percona.com_perconapgclusters.yaml
+++ b/config/crd/bases/pgv2.percona.com_perconapgclusters.yaml
@@ -21548,6 +21548,10 @@ spec:
                   version:
                     type: string
                 type: object
+              patroniVersion:
+                description: 'Deprecated: Use Patroni instead. This field will be
+                  removed in a future release.'
+                type: string
               pgbackrest:
                 description: Status information for pgBackRest
                 properties:

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -21845,6 +21845,10 @@ spec:
                   version:
                     type: string
                 type: object
+              patroniVersion:
+                description: 'Deprecated: Use Patroni instead. This field will be
+                  removed in a future release.'
+                type: string
               pgbackrest:
                 description: Status information for pgBackRest
                 properties:

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -21845,6 +21845,10 @@ spec:
                   version:
                     type: string
                 type: object
+              patroniVersion:
+                description: 'Deprecated: Use Patroni instead. This field will be
+                  removed in a future release.'
+                type: string
               pgbackrest:
                 description: Status information for pgBackRest
                 properties:

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -21845,6 +21845,10 @@ spec:
                   version:
                     type: string
                 type: object
+              patroniVersion:
+                description: 'Deprecated: Use Patroni instead. This field will be
+                  removed in a future release.'
+                type: string
               pgbackrest:
                 description: Status information for pgBackRest
                 properties:

--- a/percona/controller/pgcluster/controller_test.go
+++ b/percona/controller/pgcluster/controller_test.go
@@ -2079,6 +2079,8 @@ var _ = Describe("patroni version check", Ordered, func() {
 			Expect(k8sClient.Get(ctx, crNamespacedName, updatedCR)).Should(Succeed())
 
 			Expect(updatedCR.Status.Patroni.Version).To(Equal("3.2.1"))
+			Expect(updatedCR.Status.PatroniVersion).To(Equal("3.2.1"))
+			Expect(updatedCR.Annotations[pNaming.AnnotationPatroniVersion]).To(Equal("3.2.1"))
 		})
 	})
 
@@ -2134,7 +2136,9 @@ var _ = Describe("patroni version check", Ordered, func() {
 			}
 
 			cr2.Status.Patroni.Version = "3.1.0"
+			cr2.Status.PatroniVersion = "3.1.0"
 			cr2.Status.Postgres.ImageID = "some-image-id"
+			cr2.Annotations[pNaming.AnnotationPatroniVersion] = "3.1.0"
 
 			status := cr2.Status
 			Expect(k8sClient.Create(ctx, cr2)).Should(Succeed())
@@ -2240,6 +2244,8 @@ var _ = Describe("patroni version check", Ordered, func() {
 			Expect(k8sClient.Get(ctx, crNamespacedName2, updatedCR)).Should(Succeed())
 
 			Expect(updatedCR.Status.Patroni.Version).To(Equal("3.1.0"))
+			Expect(updatedCR.Status.PatroniVersion).To(Equal("3.1.0"))
+			Expect(updatedCR.Annotations[pNaming.AnnotationPatroniVersion]).To(Equal("3.1.0"))
 		})
 	})
 })

--- a/percona/postgres/common.go
+++ b/percona/postgres/common.go
@@ -17,7 +17,13 @@ func GetPrimaryPod(ctx context.Context, cli client.Client, cr *v2.PerconaPGClust
 	// K8SPG-648: patroni v4.0.0 deprecated "master" role.
 	//            We should use "primary" instead
 	role := "primary"
-	patroniVer, err := gover.NewVersion(cr.Status.Patroni.Version)
+
+	patroniVersion := cr.Status.PatroniVersion
+	if cr.CompareVersion("2.8.0") >= 0 {
+		patroniVersion = cr.Status.Patroni.Version
+	}
+
+	patroniVer, err := gover.NewVersion(patroniVersion)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get patroni version")
 	}

--- a/percona/watcher/wal_test.go
+++ b/percona/watcher/wal_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/percona/percona-postgresql-operator/v2/percona/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -342,6 +343,9 @@ func TestGetLatestCommitTimestamp(t *testing.T) {
 					Patroni: pgv2.Patroni{
 						Version: "error",
 					},
+				},
+				Spec: pgv2.PerconaPGClusterSpec{
+					CRVersion: version.Version(),
 				},
 			},
 			expectedErr: errors.New("failed to get patroni version: Malformed version: error: primary pod not found"),

--- a/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
+++ b/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
@@ -444,6 +444,11 @@ type PerconaPGClusterStatus struct {
 
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=status
+	// Deprecated: Use Patroni instead. This field will be removed in a future release.
+	PatroniVersion string `json:"patroniVersion"`
+
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=status
 	Patroni Patroni `json:"patroni,omitempty"`
 
 	// Status information for pgBackRest


### PR DESCRIPTION
[![K8SPG-883](https://badgen.net/badge/JIRA/K8SPG-883/green)](https://jira.percona.com/browse/K8SPG-883) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**

In 2.8.0 we have changed the status.patroniVersion -> status.patroni.version. As a result, when the 2.8.0 CRD is applied (and 2.7.0 operator is running) the patroni-version-check  pod is started again because:

```
2025-10-21T13:01:26.130Z        INFO    unknown field "status.patroniVersion"   {"controller": "perconapgcluster", "controllerGroup": "pgv2.percona.com", "controllerKind": "PerconaPGCluster", "PerconaPGCluster": {"name":"cluster1","namespace":"default"}, "namespace": "default", "name": "cluster1", "reconcileID": "694a5a02-eb14-4425-8783-1313149162ac"}
```

We need to keep the old status in CRD and make its deprecation as we usually do for the other fields in CRD, and keep the old and new ones for 3 versions. 

With this PR we are also solving a bug where the patroni version annotation is never applied to the percona pg object. 

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**

<img width="395" height="206" alt="Screenshot 2025-10-22 at 1 07 32 PM" src="https://github.com/user-attachments/assets/83a3fe6f-0cb4-48ac-a00f-571970f3b163" />
<img width="461" height="314" alt="Screenshot 2025-10-22 at 1 07 25 PM" src="https://github.com/user-attachments/assets/571ee810-db62-499a-8f9b-67248d162bff" />


**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-883]: https://perconadev.atlassian.net/browse/K8SPG-883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ