### PR TITLE
K8SPG-786: Log commands before execing them in containers

### DIFF
--- a/internal/controller/runtime/pod_client.go
+++ b/internal/controller/runtime/pod_client.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/util/flowcontrol"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // podExecutor runs command on container in pod in namespace. Non-nil streams
@@ -62,6 +63,8 @@ func NewPodExecutor(config *rest.Config) (podExecutor, error) {
 
 		exec, err := remotecommand.NewSPDYExecutor(configCopy, "POST", request.URL())
 
+		log := logf.FromContext(ctx)
+		log.V(1).Info("Running command in pod", "pod", pod, "container", container, "command", command)
 		if err == nil {
 			err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
 				Stdin:  stdin,

--- a/percona/clientcmd/clientcmd.go
+++ b/percona/clientcmd/clientcmd.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/client-go/util/retry"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type Client struct {
@@ -72,6 +73,9 @@ func (c *Client) Exec(ctx context.Context, pod *corev1.Pod, containerName string
 	if err != nil {
 		return errors.Wrap(err, "failed to create executor")
 	}
+
+	log := logf.FromContext(ctx)
+	log.V(1).Info("Running command in pod", "pod", pod.Name, "container", containerName, "command", command)
 
 	retryErr := retry.OnError(retry.DefaultRetry, func(err error) bool {
 		return true // Retry on all errors


### PR DESCRIPTION
[![K8SPG-786](https://badgen.net/badge/JIRA/K8SPG-786/green)](https://jira.percona.com/browse/K8SPG-786) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
There is no visibility of commands that operator runs in containers.

**Solution:**
Add debug logs.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-786]: https://perconadev.atlassian.net/browse/K8SPG-786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ