### PR TITLE
K8SPG-833_fix_test add stability

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -1037,7 +1037,7 @@ get_desired_replicas() {
 }
 
 get_ready_replicas() {
-  kubectl get sts "$1" -n "$NAMESPACE" -o jsonpath='{.status.readyReplicas}'
+	kubectl get sts "$1" -n "$NAMESPACE" -o jsonpath='{.status.readyReplicas}'
 }
 
 wait_sts_rollout() {
@@ -1045,7 +1045,7 @@ wait_sts_rollout() {
 	local ready_replicas=$(get_ready_replicas $sts)
 	local updated_replicas=$(get_updated_replicas $sts)
 	local desired_replicas=$(get_desired_replicas $sts)
-  echo "ready_replicas $ready_replicas desired_replicas $desired_replicas"
+	echo "ready_replicas $ready_replicas desired_replicas $desired_replicas"
 
 	until [[ $ready_replicas -eq $desired_replicas && $updated_replicas -eq $desired_replicas ]]; do
 		ready_replicas=$(get_ready_replicas $sts)


### PR DESCRIPTION
[![K8SPG-833](https://badgen.net/badge/JIRA/K8SPG-833/green)](https://jira.percona.com/browse/K8SPG-833) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
In some cases we check variable before it is available in container. To fix it, let's check that all replicas is ready. 

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPG-833]: https://perconadev.atlassian.net/browse/K8SPG-833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ