### PR TITLE
e2e-tests: fix kuttl timeout placement in migration-data-volumes

### DIFF
--- a/e2e-tests/tests/migration-data-volumes/00-start-v1-operator.yaml
+++ b/e2e-tests/tests/migration-data-volumes/00-start-v1-operator.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 10
 commands:
   - script: |-
       set -o errexit
@@ -24,3 +23,4 @@ commands:
       $sed -r 's/^(    namespace:).*pgo.*$/\1 \"'$NAMESPACE'\"/g' |
       $sed -r 's/^(    pgo_operator_namespace:).*pgo.*$/\1 \"'$OPNS'\"/g' |
       kubectl -n $NAMESPACE apply -f -
+    timeout: 10

--- a/e2e-tests/tests/migration-data-volumes/01-remove-v1-deployer.yaml
+++ b/e2e-tests/tests/migration-data-volumes/01-remove-v1-deployer.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 10
 commands:
   - script: |-
       set -o errexit
@@ -20,3 +19,4 @@ commands:
       sed -r 's/^(    namespace:).*pgo.*$/\1 \"'$NAMESPACE'\"/g' |
       sed -r 's/^(    pgo_operator_namespace:).*pgo.*$/\1 \"'$OPNS'\"/g' |
       kubectl -n $NAMESPACE delete -f -
+    timeout: 10

--- a/e2e-tests/tests/migration-data-volumes/02-start-v1-cluster.yaml
+++ b/e2e-tests/tests/migration-data-volumes/02-start-v1-cluster.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 10
 commands:
   - script: |-
       set -o errexit
@@ -29,3 +28,4 @@ commands:
         .spec.pgBouncer.image="percona/percona-postgresql-operator:'$PGOV1_TAG'-ppg'$PGOV1_VER'-pgbouncer"' - |
       $sed -r 's/cluster1/'$V1_CLUSTER_NAME'/g' |
       kubectl -n $NAMESPACE apply -f -
+    timeout: 10

--- a/e2e-tests/tests/migration-data-volumes/04-read-from-primary.yaml
+++ b/e2e-tests/tests/migration-data-volumes/04-read-from-primary.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 30
 commands:
   - script: |-
       set -o errexit
@@ -14,3 +13,4 @@ commands:
       data=$(run_psql '\c myapp \\\ SELECT * from myApp;' "postgres://postgres:$POSTGRES_V1_PASS@$POSTGRES_V1_CLUSTER_NAME")
 
       kubectl create configmap -n "$NAMESPACE" 04-read-from-primary --from-literal=data="$data"
+    timeout: 30

--- a/e2e-tests/tests/migration-data-volumes/05-deploy-operator.yaml
+++ b/e2e-tests/tests/migration-data-volumes/05-deploy-operator.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 10
 commands:
   - script: |-
       set -o errexit
@@ -10,3 +9,4 @@ commands:
 
       deploy_operator
       deploy_s3_secrets
+    timeout: 10

--- a/e2e-tests/tests/migration-data-volumes/10-read-from-primary.yaml
+++ b/e2e-tests/tests/migration-data-volumes/10-read-from-primary.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 30
 commands:
   - script: |-
       set -o errexit
@@ -11,3 +10,4 @@ commands:
       data=$(run_psql '\c myapp \\\ SELECT * from myApp;' "postgres://postgres:$(get_psql_user_pass migration-data-volumes-pguser-postgres)@$(get_psql_user_host migration-data-volumes-pguser-postgres)")
 
       kubectl create configmap -n "${NAMESPACE}" 10-read-from-primary --from-literal=data="${data}"
+    timeout: 30

--- a/e2e-tests/tests/migration-data-volumes/12-read-from-primary.yaml
+++ b/e2e-tests/tests/migration-data-volumes/12-read-from-primary.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 30
 commands:
   - script: |-
       set -o errexit
@@ -11,3 +10,4 @@ commands:
       data=$(run_psql '\c myapp \\\ SELECT * from myApp;' "postgres://postgres:$(get_psql_user_pass migration-data-volumes-pguser-postgres)@$(get_psql_user_host migration-data-volumes-pguser-postgres)")
 
       kubectl create configmap -n "${NAMESPACE}" 12-read-from-primary --from-literal=data="${data}"
+    timeout: 30


### PR DESCRIPTION
## Summary

- In the kuttl TestStep schema, `timeout` is a per-command field nested under `commands[]`; when placed at the top level, kuttl silently ignores it.
- Move the existing top-level `timeout` into the single command entry in each affected TestStep file under `e2e-tests/tests/migration-data-volumes/` so the configured timeout actually takes effect.
- Files updated: `00-start-v1-operator.yaml`, `01-remove-v1-deployer.yaml`, `02-start-v1-cluster.yaml`, `04-read-from-primary.yaml`, `05-deploy-operator.yaml`, `10-read-from-primary.yaml`, `12-read-from-primary.yaml`. Script contents are unchanged.

## Test plan

- [x] Each modified file parses as valid YAML
- [x] Each file still has `kind: TestStep`
- [x] Each file has no top-level `timeout:` line
- [x] Each file has a nested `timeout: N` under its `commands[]` entry
- [x] `git diff` confirms only the timeout line moved (no script content changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)