### PR TITLE
e2e-tests: fix kuttl timeout placement in migration-backup-s3

### DIFF
--- a/e2e-tests/tests/migration-backup-s3/00-start-v1-operator.yaml
+++ b/e2e-tests/tests/migration-backup-s3/00-start-v1-operator.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 10
 commands:
   - script: |-
       set -o errexit
@@ -24,3 +23,4 @@ commands:
       $sed -r 's/^(    namespace:).*pgo.*$/\1 \"'$NAMESPACE'\"/g' |
       $sed -r 's/^(    pgo_operator_namespace:).*pgo.*$/\1 \"'$OPNS'\"/g' |
       kubectl -n $NAMESPACE apply -f -
+    timeout: 10

--- a/e2e-tests/tests/migration-backup-s3/01-remove-v1-deployer.yaml
+++ b/e2e-tests/tests/migration-backup-s3/01-remove-v1-deployer.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 10
 commands:
   - script: |-
       set -o errexit
@@ -20,3 +19,4 @@ commands:
       sed -r 's/^(    namespace:).*pgo.*$/\1 \"'$NAMESPACE'\"/g' |
       sed -r 's/^(    pgo_operator_namespace:).*pgo.*$/\1 \"'$OPNS'\"/g' |
       kubectl -n $NAMESPACE delete -f -
+    timeout: 10

--- a/e2e-tests/tests/migration-backup-s3/02-start-v1-cluster.yaml
+++ b/e2e-tests/tests/migration-backup-s3/02-start-v1-cluster.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 10
 commands:
   - script: |-
       set -o errexit
@@ -35,3 +34,4 @@ commands:
         ' - |
       $sed -r 's/cluster1/'$V1_CLUSTER_NAME'/g' |
       kubectl -n $NAMESPACE apply -f -
+    timeout: 10

--- a/e2e-tests/tests/migration-backup-s3/04-read-from-primary.yaml
+++ b/e2e-tests/tests/migration-backup-s3/04-read-from-primary.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 30
 commands:
   - script: |-
       set -o errexit
@@ -14,3 +13,4 @@ commands:
       data=$(run_psql '\c myapp \\\ SELECT * from myApp;' "postgres://postgres:$POSTGRES_V1_PASS@$POSTGRES_V1_CLUSTER_NAME")
 
       kubectl create configmap -n "$NAMESPACE" 04-read-from-primary --from-literal=data="$data"
+    timeout: 30

--- a/e2e-tests/tests/migration-backup-s3/08-deploy-operator.yaml
+++ b/e2e-tests/tests/migration-backup-s3/08-deploy-operator.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 10
 commands:
   - script: |-
       set -o errexit
@@ -10,3 +9,4 @@ commands:
 
       deploy_operator
       deploy_s3_secrets
+    timeout: 10

--- a/e2e-tests/tests/migration-backup-s3/10-read-from-primary.yaml
+++ b/e2e-tests/tests/migration-backup-s3/10-read-from-primary.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 30
 commands:
   - script: |-
       set -o errexit
@@ -11,3 +10,4 @@ commands:
       data=$(run_psql '\c myapp \\\ SELECT * from myApp;' "postgres://postgres:$(get_psql_user_pass migration-backup-s3-pguser-postgres)@$(get_psql_user_host migration-backup-s3-pguser-postgres)")
 
       kubectl create configmap -n "${NAMESPACE}" 11-read-from-primary --from-literal=data="${data}"
+    timeout: 30

--- a/e2e-tests/tests/migration-backup-s3/12-read-from-primary.yaml
+++ b/e2e-tests/tests/migration-backup-s3/12-read-from-primary.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 30
 commands:
   - script: |-
       set -o errexit
@@ -11,3 +10,4 @@ commands:
       data=$(run_psql '\c myapp \\\ SELECT * from myApp;' "postgres://postgres:$(get_psql_user_pass migration-backup-s3-pguser-postgres)@$(get_psql_user_host migration-backup-s3-pguser-postgres)")
 
       kubectl create configmap -n "${NAMESPACE}" 12-read-from-primary --from-literal=data="${data}"
+    timeout: 30


### PR DESCRIPTION
## Summary
- Per the kuttl TestStep schema, `timeout:` is a per-command field nested under `commands[]`. When placed at the top level of a TestStep, kuttl silently ignores it — leaving these steps effectively running with the default timeout.
- Move the top-level `timeout:` in seven `migration-backup-s3` TestStep files onto the (single) entry under `commands:`, so the configured timeout actually takes effect.

Files changed (top-level `timeout` -> nested under the lone command):
- `e2e-tests/tests/migration-backup-s3/00-start-v1-operator.yaml` (10)
- `e2e-tests/tests/migration-backup-s3/01-remove-v1-deployer.yaml` (10)
- `e2e-tests/tests/migration-backup-s3/02-start-v1-cluster.yaml` (10)
- `e2e-tests/tests/migration-backup-s3/04-read-from-primary.yaml` (30)
- `e2e-tests/tests/migration-backup-s3/08-deploy-operator.yaml` (10)
- `e2e-tests/tests/migration-backup-s3/10-read-from-primary.yaml` (30)
- `e2e-tests/tests/migration-backup-s3/12-read-from-primary.yaml` (30)

No script contents are changed, and `*-assert.yaml` files (where top-level `timeout:` is valid) are untouched.

## Test plan
- [x] Each modified file parses as valid YAML (`python3 -c "import yaml; yaml.safe_load(open(f))"`).
- [x] Each file still has `kind: TestStep`.
- [x] No top-level `timeout:` remains in any modified file.
- [x] Each file now contains a `    timeout: <N>` line nested under its command.
- [x] Parsed YAML confirms `timeout` lives on `commands[0]` with the original numeric value (10 or 30).
- [ ] Run the `migration-backup-s3` kuttl suite end-to-end in CI to confirm steps still pass with the now-active timeouts.