### PR TITLE
e2e-tests: fix kuttl timeout placement in migration-from-crunchy-pv

### DIFF
--- a/e2e-tests/tests/migration-from-crunchy-pv/00-deploy-operators.yaml
+++ b/e2e-tests/tests/migration-from-crunchy-pv/00-deploy-operators.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 20
 commands:
   - script: |-
       set -o errexit
@@ -81,3 +80,4 @@ commands:
 
       deploy_operator
       deploy_client
+    timeout: 20

--- a/e2e-tests/tests/migration-from-crunchy-pv/01-create-crunchy-cluster.yaml
+++ b/e2e-tests/tests/migration-from-crunchy-pv/01-create-crunchy-cluster.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 20
 commands:
   - script: |-
       set -o errexit
@@ -24,3 +23,4 @@ commands:
         $sed "s|<repo-path>|${CRUNCHY_REPO_PATH}|g" | \
         $sed "s|<minio-endpoint>|${MINIO_ENDPOINT}|g" | \
         kubectl -n "${NAMESPACE}" apply -f -
+    timeout: 20

--- a/e2e-tests/tests/migration-from-crunchy-pv/02-write-data.yaml
+++ b/e2e-tests/tests/migration-from-crunchy-pv/02-write-data.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 60
 commands:
   - script: |-
       set -o errexit
@@ -33,3 +32,4 @@ commands:
 
       kubectl create configmap -n "${NAMESPACE}" 02-initial-data \
         --from-literal=data="${data}"
+    timeout: 60

--- a/e2e-tests/tests/migration-from-crunchy-pv/03-migrate-pv.yaml
+++ b/e2e-tests/tests/migration-from-crunchy-pv/03-migrate-pv.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 120
 commands:
   - script: |-
       set -o errexit
@@ -60,3 +59,4 @@ commands:
       helm uninstall pgo --namespace "${NAMESPACE}" --ignore-not-found || true
 
       echo "Crunchy cluster and operator removed — waiting for PV to transition to Released (03-assert)"
+    timeout: 120

--- a/e2e-tests/tests/migration-from-crunchy-pv/04-create-percona-cluster.yaml
+++ b/e2e-tests/tests/migration-from-crunchy-pv/04-create-percona-cluster.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 60
 commands:
   - script: |-
       set -o errexit
@@ -47,3 +46,4 @@ commands:
         yq eval 'del(.spec.users)' | \
         $sed "s|<minio-endpoint>|${MINIO_ENDPOINT}|g" | \
         kubectl -n "${NAMESPACE}" apply -f -
+    timeout: 60

--- a/e2e-tests/tests/migration-from-crunchy-pv/05-verify-data.yaml
+++ b/e2e-tests/tests/migration-from-crunchy-pv/05-verify-data.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 300
 commands:
   - script: |-
       set -o errexit
@@ -71,3 +70,4 @@ commands:
         --from-literal=data="$(printf '%b' "${combined}")"
 
       echo "PASS: all original rows present on all 3 pods — PV migration and replication verified"
+    timeout: 300

--- a/e2e-tests/tests/migration-from-crunchy-pv/07-restore.yaml
+++ b/e2e-tests/tests/migration-from-crunchy-pv/07-restore.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 60
 commands:
   - script: |-
       set -o errexit
@@ -51,3 +50,4 @@ commands:
         - --set=${backup_label}
         - --type=immediate
       EOF
+    timeout: 60

--- a/e2e-tests/tests/migration-from-crunchy-pv/08-verify-after-restore.yaml
+++ b/e2e-tests/tests/migration-from-crunchy-pv/08-verify-after-restore.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 60
 commands:
   - script: |-
       set -o errexit
@@ -45,3 +44,4 @@ commands:
       done
 
       echo "PASS: original migrated rows present, post-backup rows correctly absent"
+    timeout: 60

--- a/e2e-tests/tests/migration-from-crunchy-pv/99-cleanup.yaml
+++ b/e2e-tests/tests/migration-from-crunchy-pv/99-cleanup.yaml
@@ -1,6 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-timeout: 300
 delete:
   - apiVersion: pgv2.percona.com/v2
     kind: PerconaPGCluster


### PR DESCRIPTION
## Summary

In the kuttl TestStep schema, `timeout:` is a per-command field nested under `commands[]` — at the top level of a TestStep it is silently ignored. The newly added `migration-from-crunchy-pv` tests had `timeout:` at the top level, so the configured timeouts were not actually being applied. This PR moves them into the (single) command entry in each file.

The one exception is `99-cleanup.yaml`, which already had a nested `timeout: 120` on the script command — the redundant top-level `timeout: 300` is just removed; the existing nested 120 is kept intact.

## Test plan

- [x] All 9 files parse as valid YAML
- [x] `kind: TestStep` preserved in each file
- [x] No top-level `timeout:` line remains in any TestStep
- [x] Each command now has a nested `timeout:` (or, for `99-cleanup.yaml`, retains the pre-existing nested one)
- [x] `git diff` confirms only the timeout line moved — no script content changed