### PR TITLE
test: re-enable upgrade check scheduler test

### DIFF
--- a/internal/upgradecheck/http_test.go
+++ b/internal/upgradecheck/http_test.go
@@ -156,7 +156,6 @@ func TestCheckForUpgrades(t *testing.T) {
 
 // TODO(benjaminjb): Replace `fake` with envtest
 func TestCheckForUpgradesScheduler(t *testing.T) {
-	t.Skip("This test fails when run with 'go test ./...', but passes when run on its own.") // TODO: remove
 	fakeClient := setupFakeClientWithPGOScheme(t, false)
 	_, server := setupVersionServer(t, true)
 	defer server.Close()


### PR DESCRIPTION
## What

Removed a stale skip from the upgrade check scheduler test.

This test used to say it broke under `go test ./...`, but that does not repro anymore. So yeah, lets get this tiny bit of coverage back in the mix.

## Repro

On current main:

```bash
go test ./internal/upgradecheck -run TestCheckForUpgradesScheduler -count=1 -v
```

The test is reported as skipped, so the scheduler panic recovery and ticker path are not actually checked. Kinda leaving money on the table.

With this branch, the same test runs for real.

## Checked

```bash
go test ./internal/upgradecheck
go test ./...
```

I searched GitHub issues/PRs for `upgradecheck`, `checkForUpgrades`, scheduler, and the old `go test ./...` note. Did not find a direct issue to link.