### PR TITLE
K8SPG-995 update pg images with new build number for 3.0.0 release

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -183,7 +183,7 @@ spec:
 #          test-label: value
 
 
-  image: docker.io/percona/percona-distribution-postgresql:18.3-1
+  image: docker.io/percona/percona-distribution-postgresql:18.3-2
   imagePullPolicy: Always
   postgresVersion: 18
 #  port: 5432

--- a/deploy/upgrade.yaml
+++ b/deploy/upgrade.yaml
@@ -7,6 +7,6 @@ spec:
   image: docker.io/percona/percona-postgresql-operator:3.0.0-upgrade
   fromPostgresVersion: 17
   toPostgresVersion: 18
-  toPostgresImage: docker.io/percona/percona-distribution-postgresql:18.3-1
+  toPostgresImage: docker.io/percona/percona-distribution-postgresql:18.3-2
   toPgBouncerImage: docker.io/percona/percona-pgbouncer:1.25.1-1
   toPgBackRestImage: docker.io/percona/percona-pgbackrest:2.58.0-1

--- a/e2e-tests/release_versions
+++ b/e2e-tests/release_versions
@@ -1,28 +1,28 @@
 IMAGE_OPERATOR=percona/percona-postgresql-operator:3.0.0
 
-IMAGE_POSTGRESQL14=percona/percona-distribution-postgresql:14.22-1
+IMAGE_POSTGRESQL14=percona/percona-distribution-postgresql:14.22-2
 IMAGE_PGBOUNCER14=percona/percona-pgbouncer:1.25.1-1
-IMAGE_POSTGIS14=percona/percona-distribution-postgresql-with-postgis:14.22-1
+IMAGE_POSTGIS14=percona/percona-distribution-postgresql-with-postgis:14.22-2
 IMAGE_BACKREST14=percona/percona-pgbackrest:2.58.0-1
 
-IMAGE_POSTGRESQL15=percona/percona-distribution-postgresql:15.17-1
+IMAGE_POSTGRESQL15=percona/percona-distribution-postgresql:15.17-2
 IMAGE_PGBOUNCER15=percona/percona-pgbouncer:1.25.1-1
-IMAGE_POSTGIS15=percona/percona-distribution-postgresql-with-postgis:15.17-1
+IMAGE_POSTGIS15=percona/percona-distribution-postgresql-with-postgis:15.17-2
 IMAGE_BACKREST15=percona/percona-pgbackrest:2.58.0-1
 
-IMAGE_POSTGRESQL16=percona/percona-distribution-postgresql:16.13-1
+IMAGE_POSTGRESQL16=percona/percona-distribution-postgresql:16.13-2
 IMAGE_PGBOUNCER16=percona/percona-pgbouncer:1.25.1-1
-IMAGE_POSTGIS16=percona/percona-distribution-postgresql-with-postgis:16.13-1
+IMAGE_POSTGIS16=percona/percona-distribution-postgresql-with-postgis:16.13-2
 IMAGE_BACKREST16=percona/percona-pgbackrest:2.58.0-1
 
-IMAGE_POSTGRESQL17=percona/percona-distribution-postgresql:17.9-1
+IMAGE_POSTGRESQL17=percona/percona-distribution-postgresql:17.9-2
 IMAGE_PGBOUNCER17=percona/percona-pgbouncer:1.25.1-1
-IMAGE_POSTGIS17=percona/percona-distribution-postgresql-with-postgis:17.9-1
+IMAGE_POSTGIS17=percona/percona-distribution-postgresql-with-postgis:17.9-2
 IMAGE_BACKREST17=percona/percona-pgbackrest:2.58.0-1
 
-IMAGE_POSTGRESQL18=percona/percona-distribution-postgresql:18.3-1
+IMAGE_POSTGRESQL18=percona/percona-distribution-postgresql:18.3-2
 IMAGE_PGBOUNCER18=percona/percona-pgbouncer:1.25.1-1
-IMAGE_POSTGIS18=percona/percona-distribution-postgresql-with-postgis:18.3-1
+IMAGE_POSTGIS18=percona/percona-distribution-postgresql-with-postgis:18.3-2
 IMAGE_BACKREST18=percona/percona-pgbackrest:2.58.0-1
 
 IMAGE_UPGRADE=percona/percona-postgresql-operator:3.0.0-upgrade


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
Latest build number for PG is -2.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
