### PR TITLE
K8SPG-1007: Fix stuck migration due to K8SPG-1017

### DIFF
--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -37,6 +37,7 @@ import (
 	"github.com/percona/percona-postgresql-operator/v2/internal/pgbackrest"
 	"github.com/percona/percona-postgresql-operator/v2/internal/pki"
 	"github.com/percona/percona-postgresql-operator/v2/internal/postgres"
+	"github.com/percona/percona-postgresql-operator/v2/percona/certmanager"
 	"github.com/percona/percona-postgresql-operator/v2/percona/k8s"
 	pNaming "github.com/percona/percona-postgresql-operator/v2/percona/naming"
 	"github.com/percona/percona-postgresql-operator/v2/pkg/apis/upstream.pgv2.percona.com/v1beta1"
@@ -1477,9 +1478,11 @@ func (r *Reconciler) reconcileInstanceConfigMap(
 // +kubebuilder:rbac:groups="",resources="secrets",verbs={create,patch}
 
 // reconcileInstanceCertificates writes the Secret that contains certificates
-// and private keys for instance of cluster. When cert-manager is installed,
-// it creates a Certificate CR and augments the resulting secret with Patroni
-// and pgBackRest keys. Otherwise, it uses internal PKI.
+// and private keys for instance of cluster. When the root CA is cert-manager-
+// managed, it creates a Certificate CR and augments the resulting secret with
+// Patroni and pgBackRest keys. Otherwise, it uses internal PKI — first
+// reconciling any stale Certificate CR left by K8SPG-1017 to update its
+// ownerRef (K8SPG-1007 recovery).
 func (r *Reconciler) reconcileInstanceCertificates(
 	ctx context.Context, cluster *v1beta1.PostgresCluster,
 	spec *v1beta1.PostgresInstanceSetSpec, instance *appsv1.StatefulSet,
@@ -1493,6 +1496,16 @@ func (r *Reconciler) reconcileInstanceCertificates(
 
 		if certManagerManaged {
 			return r.reconcileCertManagerInstanceCertificates(ctx, cluster, spec, instance, rootCertificateAuth)
+		}
+
+		// cluster certificates are not managed by cert-manager
+		// but Certificate object exists due to the bug described in K8SPG-1017
+		// we need to reconcile them anyway to update ownerRef for K8SPG-1007.
+		if cert := certmanager.InstanceCertificateName(instance.Name); r.shouldReconcileCertManagerCertificate(ctx, cluster.Namespace, cert) {
+			_, err := r.reconcileCertManagerInstanceCertificates(ctx, cluster, spec, instance, rootCertificateAuth)
+			if err != nil {
+				logging.FromContext(ctx).Error(err, "failed to reconcile Certificate", "name", cert)
+			}
 		}
 	}
 

--- a/internal/controller/postgrescluster/patroni.go
+++ b/internal/controller/postgrescluster/patroni.go
@@ -21,6 +21,7 @@ import (
 	"github.com/percona/percona-postgresql-operator/v2/internal/patroni"
 	"github.com/percona/percona-postgresql-operator/v2/internal/pki"
 	"github.com/percona/percona-postgresql-operator/v2/internal/postgres"
+	"github.com/percona/percona-postgresql-operator/v2/percona/certmanager"
 	"github.com/percona/percona-postgresql-operator/v2/pkg/apis/upstream.pgv2.percona.com/v1beta1"
 )
 
@@ -386,6 +387,16 @@ func (r *Reconciler) reconcileReplicationSecret(
 
 	if certManagerManaged {
 		return r.reconcileCertManagerReplicationSecret(ctx, cluster)
+	}
+
+	// cluster certificates are not managed by cert-manager
+	// but Certificate object exists due to the bug described in K8SPG-1017
+	// we need to reconcile them anyway to update ownerRef for K8SPG-1007.
+	if cert := certmanager.ReplicationCertificateName(cluster); r.shouldReconcileCertManagerCertificate(ctx, cluster.Namespace, cert) {
+		_, err := r.reconcileCertManagerReplicationSecret(ctx, cluster)
+		if err != nil {
+			logging.FromContext(ctx).Error(err, "failed to reconcile Certificate", "name", cert)
+		}
 	}
 
 	return r.reconcileInternalReplicationSecret(ctx, cluster, root)

--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -40,6 +40,7 @@ import (
 	"github.com/percona/percona-postgresql-operator/v2/internal/pgbackrest"
 	"github.com/percona/percona-postgresql-operator/v2/internal/pki"
 	"github.com/percona/percona-postgresql-operator/v2/internal/postgres"
+	"github.com/percona/percona-postgresql-operator/v2/percona/certmanager"
 	"github.com/percona/percona-postgresql-operator/v2/percona/k8s"
 	pNaming "github.com/percona/percona-postgresql-operator/v2/percona/naming"
 	v2 "github.com/percona/percona-postgresql-operator/v2/pkg/apis/pgv2.percona.com/v2"
@@ -2239,6 +2240,16 @@ func (r *Reconciler) reconcilePGBackRestSecret(ctx context.Context,
 		if certManagerManaged {
 			err = r.reconcileCertManagerPGBackRestSecret(ctx, cluster, repoHost, rootCA, existing, intent)
 		} else {
+			// cluster certificates are not managed by cert-manager
+			// but Certificate object exists due to the bug described in K8SPG-1017
+			// we need to reconcile them anyway to update ownerRef for K8SPG-1007.
+			if cert := certmanager.PGBackRestClientCertificateName(cluster); r.shouldReconcileCertManagerCertificate(ctx, cluster.Namespace, cert) {
+				err := r.reconcileCertManagerPGBackRestSecret(ctx, cluster, repoHost, rootCA, existing, intent)
+				if err != nil {
+					logging.FromContext(ctx).Error(err, "failed to reconcile Certificate", "name", cert)
+				}
+			}
+
 			err = pgbackrest.Secret(ctx, cluster, repoHost, rootCA, existing, intent)
 		}
 	} else if err == nil {

--- a/internal/controller/postgrescluster/pgbouncer.go
+++ b/internal/controller/postgrescluster/pgbouncer.go
@@ -13,6 +13,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -24,6 +25,7 @@ import (
 	"github.com/percona/percona-postgresql-operator/v2/internal/pgbouncer"
 	"github.com/percona/percona-postgresql-operator/v2/internal/pki"
 	"github.com/percona/percona-postgresql-operator/v2/internal/postgres"
+	"github.com/percona/percona-postgresql-operator/v2/percona/certmanager"
 	"github.com/percona/percona-postgresql-operator/v2/pkg/apis/upstream.pgv2.percona.com/v1beta1"
 )
 
@@ -195,14 +197,56 @@ func (r *Reconciler) reconcilePGBouncerInPostgreSQL(
 // +kubebuilder:rbac:groups="",resources="secrets",verbs={get}
 // +kubebuilder:rbac:groups="",resources="secrets",verbs={create,delete,patch}
 
+// reconcileCertManagerPGBouncerSecret applies the cert-manager Certificate CR
+// for the PgBouncer frontend and returns the resulting -frontend-tls Secret,
+// which the caller uses to populate the main pgbouncer secret with the
+// cert-manager-issued material. Returns (nil, nil) when the Certificate has
+// been applied but cert-manager has not yet issued the Secret, so callers can
+// continue reconciling with internal-PKI material during the transition.
+func (r *Reconciler) reconcileCertManagerPGBouncerSecret(ctx context.Context, cluster *v1beta1.PostgresCluster, service *corev1.Service) (*corev1.Secret, error) {
+	log := logging.FromContext(ctx)
+
+	c := r.CertManagerCtrlFunc(r.Client, r.Scheme, false)
+
+	dnsNames, dnsErr := naming.ServiceDNSNames(ctx, service, cluster.Spec.ClusterServiceDNSSuffix)
+	if dnsErr != nil {
+		return nil, errors.Wrap(dnsErr, "get pgbouncer service DNS names")
+	}
+
+	err := c.ApplyPGBouncerCertificate(ctx, cluster, dnsNames)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to apply pgbouncer certificate")
+	}
+
+	log.V(1).Info("cert-manager pgbouncer certificate applied")
+
+	// Fetch the cert-manager-managed frontend TLS secret to populate
+	// the main pgbouncer secret with cert-manager-issued certs.
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name:      naming.ClusterPGBouncer(cluster).Name + "-frontend-tls",
+		Namespace: cluster.Namespace,
+	}}
+	err = r.Client.Get(ctx, client.ObjectKeyFromObject(secret), secret)
+	if k8serrors.IsNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get pgbouncer frontend TLS secret")
+	}
+
+	return secret, nil
+}
+
 // reconcilePGBouncerSecret writes the Secret for a PgBouncer Pod.
-// When cert-manager is installed and no custom TLS secret is provided,
-// it creates a Certificate CR for PgBouncer frontend TLS.
+// When the root CA is cert-manager-managed and no custom TLS secret is
+// provided, it creates a Certificate CR for PgBouncer frontend TLS.
+// When the root CA is internal but a stale Certificate CR was left by
+// K8SPG-1017, the CR is reconciled to update its ownerRef (K8SPG-1007
+// recovery) before populating the secret from the internal PKI.
 func (r *Reconciler) reconcilePGBouncerSecret(
 	ctx context.Context, cluster *v1beta1.PostgresCluster,
 	root *pki.RootCertificateAuthority, service *corev1.Service,
 ) (*corev1.Secret, error) {
-	log := logging.FromContext(ctx)
 
 	existing := &corev1.Secret{ObjectMeta: naming.ClusterPGBouncer(cluster)}
 	err := errors.WithStack(
@@ -229,32 +273,22 @@ func (r *Reconciler) reconcilePGBouncerSecret(
 		}
 
 		if certManagerManaged {
-			c := r.CertManagerCtrlFunc(r.Client, r.Scheme, false)
-
-			dnsNames, dnsErr := naming.ServiceDNSNames(ctx, service, cluster.Spec.ClusterServiceDNSSuffix)
-			if dnsErr != nil {
-				return nil, errors.Wrap(dnsErr, "get pgbouncer service DNS names")
+			s, err := r.reconcileCertManagerPGBouncerSecret(ctx, cluster, service)
+			if err != nil {
+				return nil, errors.Wrap(err, "reconcile cert-manager Certificate for pgbouncer frontend")
 			}
-
-			certErr = c.ApplyPGBouncerCertificate(ctx, cluster, dnsNames)
-			if certErr != nil {
-				return nil, errors.Wrap(certErr, "failed to apply pgbouncer certificate")
-			}
-
-			log.V(1).Info("cert-manager pgbouncer certificate applied")
-
-			// Fetch the cert-manager-managed frontend TLS secret to populate
-			// the main pgbouncer secret with cert-manager-issued certs.
-			s := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
-				Name:      naming.ClusterPGBouncer(cluster).Name + "-frontend-tls",
-				Namespace: cluster.Namespace,
-			}}
-			fetchErr := r.Client.Get(ctx, client.ObjectKeyFromObject(s), s)
-			if fetchErr != nil && client.IgnoreNotFound(fetchErr) != nil {
-				return nil, errors.Wrap(fetchErr, "failed to get pgbouncer frontend TLS secret")
-			}
-			if fetchErr == nil {
-				frontendCertManagerSecret = s
+			// s is nil when cert-manager has not yet issued the frontend TLS secret;
+			// the caller will fall through to internal PKI material during that window.
+			frontendCertManagerSecret = s
+		} else {
+			// cluster certificates are not managed by cert-manager
+			// but Certificate object exists due to the bug described in K8SPG-1017
+			// we need to reconcile them anyway to update ownerRef for K8SPG-1007.
+			if cert := certmanager.PGBouncerCertificateName(cluster); r.shouldReconcileCertManagerCertificate(ctx, cluster.Namespace, cert) {
+				_, err := r.reconcileCertManagerPGBouncerSecret(ctx, cluster, service)
+				if err != nil {
+					logging.FromContext(ctx).Error(err, "failed to reconcile Certificate", "name", cert)
+				}
 			}
 		}
 	}

--- a/internal/controller/postgrescluster/pki.go
+++ b/internal/controller/postgrescluster/pki.go
@@ -202,14 +202,13 @@ func (r *Reconciler) reconcileCertManagerRootCertificate(
 // +kubebuilder:rbac:groups="",resources="secrets",verbs={get}
 // +kubebuilder:rbac:groups="",resources="secrets",verbs={create,patch}
 
-// reconcileClusterCertificate first checks if a custom certificate
-// secret is configured. If so, that secret projection is returned.
-// Otherwise, it checks if cert-manager is installed. If installed, cert-manager
-// is used to create and manage the certificate. Otherwise, a secret containing
-// a generated leaf certificate is created using the internal PKI.
-// In either case, the relevant secret is expected to contain three files:
-// tls.crt, tls.key and ca.crt which are the TLS certificate, private key
-// and CA certificate, respectively.
+// reconcileClusterCertificate returns the cluster TLS secret projection.
+// If CustomTLSSecret is set, that projection is returned. Otherwise the
+// path depends on the root CA: when it is cert-manager-managed,
+// cert-manager issues the leaf; when it is internal but a stale
+// Certificate CR is left behind by K8SPG-1017, the CR is reconciled
+// (K8SPG-1007 ownerRef recovery) before falling back to the internal PKI
+// leaf. The returned secret contains tls.crt, tls.key and ca.crt.
 func (r *Reconciler) reconcileClusterCertificate(
 	ctx context.Context, root *pki.RootCertificateAuthority,
 	cluster *v1beta1.PostgresCluster, primaryService *corev1.Service,
@@ -228,6 +227,16 @@ func (r *Reconciler) reconcileClusterCertificate(
 
 	if certManagerManaged {
 		return r.reconcileCertManagerClusterCertificate(ctx, root, cluster, primaryService, replicaService)
+	}
+
+	// cluster certificates are not managed by cert-manager
+	// but Certificate object exists due to the bug described in K8SPG-1017
+	// we need to reconcile them anyway to update ownerRef for K8SPG-1007.
+	if cert := certmanager.ClusterCertificateName(cluster); r.shouldReconcileCertManagerCertificate(ctx, cluster.Namespace, cert) {
+		_, err := r.reconcileCertManagerClusterCertificate(ctx, root, cluster, primaryService, replicaService)
+		if err != nil {
+			logging.FromContext(ctx).Error(err, "failed to reconcile Certificate", "name", cert)
+		}
 	}
 
 	return r.reconcileInternalClusterCertificate(ctx, root, cluster, primaryService, replicaService)
@@ -349,6 +358,26 @@ func (r *Reconciler) reconcileCertManagerClusterCertificate(
 	return clusterCertSecretProjection(&corev1.Secret{
 		ObjectMeta: naming.PostgresTLSSecret(cluster),
 	}), nil
+}
+
+// shouldReconcileCertManagerCertificate reports whether a stale cert-manager
+// Certificate CR exists for the cluster and should be reconciled to update
+// its ownerRef (K8SPG-1007 recovery for Certificates left behind by the
+// K8SPG-1017 bug). Returns false when cert-manager is not installed or the
+// Certificate CR does not exist.
+func (r *Reconciler) shouldReconcileCertManagerCertificate(ctx context.Context, namespace, certName string) bool {
+	installed, err := r.isCertManagerInstalled(ctx, namespace)
+	if err != nil || !installed {
+		return false
+	}
+
+	// CertificateExists is read-only, so use the dry-run controller to match
+	// the intent (no mutating cert-manager calls happen on this path).
+	c := r.CertManagerCtrlFunc(r.Client, r.Scheme, true /* dry run */)
+
+	exists, err := c.CertificateExists(ctx, namespace, certName)
+
+	return err == nil && exists
 }
 
 func (r *Reconciler) isRootCACertManagerManaged(ctx context.Context, cluster *v1beta1.PostgresCluster) (bool, error) {

--- a/internal/controller/postgrescluster/pki_test.go
+++ b/internal/controller/postgrescluster/pki_test.go
@@ -394,6 +394,9 @@ func TestReconcileCerts(t *testing.T) {
 type mockCertManagerController struct{}
 
 func (m *mockCertManagerController) Check(context.Context, *rest.Config, string) error { return nil }
+func (m *mockCertManagerController) CertificateExists(context.Context, string, string) (bool, error) {
+	return false, nil
+}
 func (m *mockCertManagerController) ApplyIssuer(context.Context, *v1beta1.PostgresCluster) error {
 	panic("unexpected call")
 }
@@ -424,6 +427,59 @@ func (m *mockCertManagerController) ApplyPGBackRestRepoCertificate(context.Conte
 
 func mockCertManagerCtrlFunc(_ client.Client, _ *runtime.Scheme, _ bool) certmanager.Controller {
 	return &mockCertManagerController{}
+}
+
+// recoveryCertManagerController reports the cert-manager Certificate object as
+// existing and records which Apply* methods are invoked. It drives the
+// K8SPG-1007 recovery branches that reconcile a stale Certificate left behind
+// by the K8SPG-1017 bug, when the cluster otherwise uses internal PKI.
+type recoveryCertManagerController struct {
+	applyIssuerCalls               int
+	applyClusterCertificateCalls   int
+	applyInstanceCertificateCalls  int
+	applyPGBouncerCertificateCalls int
+	applyReplicationCalls          int
+	applyPGBackRestClientCalls     int
+}
+
+func (m *recoveryCertManagerController) Check(context.Context, *rest.Config, string) error {
+	return nil
+}
+func (m *recoveryCertManagerController) CertificateExists(context.Context, string, string) (bool, error) {
+	return true, nil
+}
+func (m *recoveryCertManagerController) ApplyIssuer(context.Context, *v1beta1.PostgresCluster) error {
+	m.applyIssuerCalls++
+	return nil
+}
+func (m *recoveryCertManagerController) ApplyCAIssuer(context.Context, *v1beta1.PostgresCluster) error {
+	return nil
+}
+func (m *recoveryCertManagerController) ApplyCACertificate(context.Context, *v1beta1.PostgresCluster) error {
+	return nil
+}
+func (m *recoveryCertManagerController) ApplyClusterCertificate(context.Context, *v1beta1.PostgresCluster, []string) error {
+	m.applyClusterCertificateCalls++
+	return nil
+}
+func (m *recoveryCertManagerController) ApplyInstanceCertificate(context.Context, *v1beta1.PostgresCluster, string, []string) error {
+	m.applyInstanceCertificateCalls++
+	return nil
+}
+func (m *recoveryCertManagerController) ApplyPGBouncerCertificate(context.Context, *v1beta1.PostgresCluster, []string) error {
+	m.applyPGBouncerCertificateCalls++
+	return nil
+}
+func (m *recoveryCertManagerController) ApplyReplicationCertificate(context.Context, *v1beta1.PostgresCluster) error {
+	m.applyReplicationCalls++
+	return nil
+}
+func (m *recoveryCertManagerController) ApplyPGBackRestClientCertificate(context.Context, *v1beta1.PostgresCluster) error {
+	m.applyPGBackRestClientCalls++
+	return nil
+}
+func (m *recoveryCertManagerController) ApplyPGBackRestRepoCertificate(context.Context, *v1beta1.PostgresCluster, []string) error {
+	return nil
 }
 
 func TestUpgradeCertManagerDoesNotTakeOverInternalPKI(t *testing.T) {
@@ -498,6 +554,166 @@ func TestUpgradeCertManagerDoesNotTakeOverInternalPKI(t *testing.T) {
 		}, updatedCertSecret))
 
 		assert.DeepEqual(t, originalCertData, updatedCertSecret.Data["tls.crt"])
+	})
+
+	t.Run("shouldReconcileCertManagerCertificate", func(t *testing.T) {
+		t.Run("returns false when cert-manager is not installed", func(t *testing.T) {
+			// RestConfig is nil, so isCertManagerInstalled short-circuits to false.
+			r := &Reconciler{
+				Client:              tClient,
+				Owner:               ControllerName,
+				CertManagerCtrlFunc: mockCertManagerCtrlFunc,
+			}
+			assert.Assert(t, !r.shouldReconcileCertManagerCertificate(ctx, namespace, "any-cert"))
+		})
+
+		t.Run("returns false when cert-manager Certificate does not exist", func(t *testing.T) {
+			// The default mockCertManagerController reports CertificateExists=false.
+			r := &Reconciler{
+				Client:              tClient,
+				Owner:               ControllerName,
+				CertManagerCtrlFunc: mockCertManagerCtrlFunc,
+				RestConfig:          &rest.Config{},
+			}
+			assert.Assert(t, !r.shouldReconcileCertManagerCertificate(ctx, namespace, "missing-cert"))
+		})
+
+		t.Run("returns true when cert-manager is installed and Certificate exists", func(t *testing.T) {
+			r := &Reconciler{
+				Client: tClient,
+				Owner:  ControllerName,
+				CertManagerCtrlFunc: func(_ client.Client, _ *runtime.Scheme, _ bool) certmanager.Controller {
+					return &recoveryCertManagerController{}
+				},
+				RestConfig: &rest.Config{},
+			}
+			assert.Assert(t, r.shouldReconcileCertManagerCertificate(ctx, namespace, "any-cert"))
+		})
+	})
+
+	t.Run("reconcileClusterCertificate recovers stale cert-manager Certificate (K8SPG-1007)", func(t *testing.T) {
+		// Internal PKI is in use (root CA secret has no cert-manager annotation),
+		// but a stale Certificate CR was left behind by K8SPG-1017. The reconciler
+		// should reconcile it to update ownerRefs, then still write the internal
+		// leaf secret.
+		recovery := &recoveryCertManagerController{}
+		r := &Reconciler{
+			Client: tClient,
+			Owner:  ControllerName,
+			CertManagerCtrlFunc: func(_ client.Client, _ *runtime.Scheme, _ bool) certmanager.Controller {
+				return recovery
+			},
+			RestConfig: &rest.Config{},
+		}
+
+		preCertData := clusterCertSecret.Data["tls.crt"]
+		_, err := r.reconcileClusterCertificate(ctx, root, cluster, primaryService, replicaService)
+		assert.NilError(t, err)
+
+		assert.Equal(t, recovery.applyIssuerCalls, 1)
+		assert.Equal(t, recovery.applyClusterCertificateCalls, 1)
+
+		// Internal leaf is still written by the fall-through path.
+		updatedCertSecret := &corev1.Secret{}
+		assert.NilError(t, tClient.Get(ctx, types.NamespacedName{
+			Name:      fmt.Sprintf(naming.ClusterCertSecret, cluster.Name),
+			Namespace: namespace,
+		}, updatedCertSecret))
+		assert.DeepEqual(t, preCertData, updatedCertSecret.Data["tls.crt"])
+	})
+
+	t.Run("reconcileInstanceCertificates recovers stale cert-manager Certificate (K8SPG-1007)", func(t *testing.T) {
+		recovery := &recoveryCertManagerController{}
+		r := &Reconciler{
+			Client: tClient,
+			Owner:  ControllerName,
+			CertManagerCtrlFunc: func(_ client.Client, _ *runtime.Scheme, _ bool) certmanager.Controller {
+				return recovery
+			},
+			RestConfig: &rest.Config{},
+		}
+
+		instance := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      cluster.Name + "-instance1-abcd",
+		}}
+		instance.Spec.ServiceName = cluster.Name + "-pods"
+		spec := &cluster.Spec.InstanceSets[0]
+
+		returned, err := r.reconcileInstanceCertificates(ctx, cluster, spec, instance, root)
+		assert.NilError(t, err)
+		assert.Equal(t, recovery.applyInstanceCertificateCalls, 1)
+		// Fall-through wrote the internal-PKI leaf into the instance certs secret.
+		assert.Assert(t, len(returned.Data) > 0)
+	})
+
+	t.Run("reconcileReplicationSecret recovers stale cert-manager Certificate (K8SPG-1007)", func(t *testing.T) {
+		recovery := &recoveryCertManagerController{}
+		r := &Reconciler{
+			Client: tClient,
+			Owner:  ControllerName,
+			CertManagerCtrlFunc: func(_ client.Client, _ *runtime.Scheme, _ bool) certmanager.Controller {
+				return recovery
+			},
+			RestConfig: &rest.Config{},
+		}
+
+		returned, err := r.reconcileReplicationSecret(ctx, cluster, root)
+		assert.NilError(t, err)
+		assert.Equal(t, recovery.applyReplicationCalls, 1)
+		// Fall-through wrote the internal-PKI replication leaf.
+		assert.Assert(t, len(returned.Data) > 0)
+	})
+
+	t.Run("reconcilePGBackRestSecret recovers stale cert-manager Certificate (K8SPG-1007)", func(t *testing.T) {
+		recovery := &recoveryCertManagerController{}
+		r := &Reconciler{
+			Client: tClient,
+			Owner:  ControllerName,
+			CertManagerCtrlFunc: func(_ client.Client, _ *runtime.Scheme, _ bool) certmanager.Controller {
+				return recovery
+			},
+			RestConfig: &rest.Config{},
+		}
+
+		repoHost := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      cluster.Name + "-repo-host",
+		}}
+		repoHost.Spec.ServiceName = cluster.Name + "-pods"
+
+		assert.NilError(t, r.reconcilePGBackRestSecret(ctx, cluster, repoHost, root))
+		assert.Equal(t, recovery.applyPGBackRestClientCalls, 1)
+		// Fall-through wrote the internal-PKI pgBackRest secret to the API.
+		pgbackrestSecret := &corev1.Secret{}
+		assert.NilError(t, tClient.Get(ctx, types.NamespacedName{
+			Name:      naming.PGBackRestSecret(cluster).Name,
+			Namespace: namespace,
+		}, pgbackrestSecret))
+		assert.Assert(t, len(pgbackrestSecret.Data) > 0)
+	})
+
+	t.Run("reconcilePGBouncerSecret recovers stale cert-manager Certificate (K8SPG-1007)", func(t *testing.T) {
+		recovery := &recoveryCertManagerController{}
+		r := &Reconciler{
+			Client: tClient,
+			Owner:  ControllerName,
+			CertManagerCtrlFunc: func(_ client.Client, _ *runtime.Scheme, _ bool) certmanager.Controller {
+				return recovery
+			},
+			RestConfig: &rest.Config{},
+		}
+
+		pgbouncerService := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      cluster.Name + "-pgbouncer",
+		}}
+
+		returned, err := r.reconcilePGBouncerSecret(ctx, cluster, root, pgbouncerService)
+		assert.NilError(t, err)
+		assert.Equal(t, recovery.applyPGBouncerCertificateCalls, 1)
+		// Fall-through populated the pgbouncer secret from internal PKI.
+		assert.Assert(t, len(returned.Data) > 0)
 	})
 
 	t.Run("isRootCACertManagerManaged returns true for cert-manager root", func(t *testing.T) {

--- a/percona/certmanager/certmanager.go
+++ b/percona/certmanager/certmanager.go
@@ -25,6 +25,8 @@ import (
 
 type Controller interface {
 	Check(ctx context.Context, config *rest.Config, ns string) error
+	CertificateExists(ctx context.Context, namespace, certName string) (bool, error)
+
 	ApplyIssuer(ctx context.Context, cluster *v1beta1.PostgresCluster) error
 	ApplyCAIssuer(ctx context.Context, cluster *v1beta1.PostgresCluster) error
 	ApplyCACertificate(ctx context.Context, cluster *v1beta1.PostgresCluster) error
@@ -91,6 +93,23 @@ func (c *controller) Check(ctx context.Context, config *rest.Config, ns string) 
 		return err
 	}
 	return nil
+}
+
+// CertificateExists reports whether a cert-manager Certificate CR with the
+// given name exists in the namespace. NotFound is returned as (false, nil);
+// other API errors are returned as (false, err).
+func (c *controller) CertificateExists(ctx context.Context, namespace, certName string) (bool, error) {
+	existing := &v1.Certificate{}
+	err := c.cl.Get(ctx, types.NamespacedName{Name: certName, Namespace: namespace}, existing)
+	if err == nil {
+		return true, nil
+	}
+
+	if k8serrors.IsNotFound(err) {
+		return false, nil
+	}
+
+	return false, errors.Wrapf(err, "get certificate/%s", certName)
 }
 
 func (c *controller) ApplyIssuer(ctx context.Context, cluster *v1beta1.PostgresCluster) error {
@@ -291,7 +310,7 @@ func (c *controller) ApplyClusterCertificate(ctx context.Context, cluster *v1bet
 		return errors.New("dnsNames cannot be empty")
 	}
 
-	certName := naming.PostgresTLSSecret(cluster).Name
+	certName := ClusterCertificateName(cluster)
 
 	certDuration := DefaultCertDuration
 	if cluster.Spec.TLS != nil && cluster.Spec.TLS.CertValidityDuration != nil {
@@ -393,7 +412,7 @@ func (c *controller) ApplyInstanceCertificate(ctx context.Context, cluster *v1be
 		return errors.New("dnsNames cannot be empty")
 	}
 
-	certName := instanceName + "-cert"
+	certName := InstanceCertificateName(instanceName)
 	secretName := instanceName + "-certs"
 
 	certDuration := DefaultCertDuration
@@ -496,7 +515,7 @@ func (c *controller) ApplyPGBouncerCertificate(ctx context.Context, cluster *v1b
 	}
 
 	secretMeta := naming.ClusterPGBouncer(cluster)
-	certName := cluster.Name + "-pgbouncer-cert"
+	certName := PGBouncerCertificateName(cluster)
 
 	certDuration := DefaultCertDuration
 	if cluster.Spec.TLS != nil && cluster.Spec.TLS.CertValidityDuration != nil {
@@ -594,7 +613,7 @@ func (c *controller) ApplyPGBouncerCertificate(ctx context.Context, cluster *v1b
 // ApplyReplicationCertificate creates a cert-manager Certificate resource for the replication client.
 func (c *controller) ApplyReplicationCertificate(ctx context.Context, cluster *v1beta1.PostgresCluster) error {
 	secretMeta := naming.ReplicationClientCertSecret(cluster)
-	certName := cluster.Name + "-replication-cert"
+	certName := ReplicationCertificateName(cluster)
 	commonName := "_crunchyrepl"
 
 	certDuration := DefaultCertDuration
@@ -694,7 +713,7 @@ func (c *controller) ApplyReplicationCertificate(ctx context.Context, cluster *v
 // repository host.
 func (c *controller) ApplyPGBackRestClientCertificate(ctx context.Context, cluster *v1beta1.PostgresCluster) error {
 	secretMeta := naming.PGBackRestClientCertSecret(cluster)
-	certName := cluster.Name + "-pgbackrest-client-cert"
+	certName := PGBackRestClientCertificateName(cluster)
 
 	certDuration := DefaultCertDuration
 	if cluster.Spec.TLS != nil && cluster.Spec.TLS.PGBackRestCertValidityDuration != nil {
@@ -804,7 +823,7 @@ func (c *controller) ApplyPGBackRestRepoCertificate(ctx context.Context, cluster
 	}
 
 	secretMeta := naming.PGBackRestRepoCertSecret(cluster)
-	certName := cluster.Name + "-pgbackrest-repo-cert"
+	certName := PGBackRestRepoCertificateName(cluster)
 
 	certDuration := DefaultCertDuration
 	if cluster.Spec.TLS != nil && cluster.Spec.TLS.PGBackRestCertValidityDuration != nil {

--- a/percona/certmanager/names.go
+++ b/percona/certmanager/names.go
@@ -1,0 +1,54 @@
+// Copyright 2024 Percona LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package certmanager
+
+import (
+	"github.com/percona/percona-postgresql-operator/v2/internal/naming"
+	"github.com/percona/percona-postgresql-operator/v2/pkg/apis/upstream.pgv2.percona.com/v1beta1"
+)
+
+// Names of the cert-manager Certificate CRs that this controller manages.
+// These are the single source of truth — both the Apply* methods that create
+// the Certificates and the callers that look them up (e.g. the K8SPG-1007
+// recovery branches) must use these helpers so the two stay in sync.
+
+// ClusterCertificateName returns the name of the cert-manager Certificate CR
+// that issues the cluster TLS leaf. The Certificate and its issued Secret
+// share a name.
+func ClusterCertificateName(cluster *v1beta1.PostgresCluster) string {
+	return naming.PostgresTLSSecret(cluster).Name
+}
+
+// InstanceCertificateName returns the name of the cert-manager Certificate CR
+// that issues an instance's leaf. instanceName is the instance's StatefulSet
+// name.
+func InstanceCertificateName(instanceName string) string {
+	return instanceName + "-cert"
+}
+
+// ReplicationCertificateName returns the name of the cert-manager Certificate
+// CR that issues the Patroni replication client leaf. The Certificate and its
+// issued Secret share a name.
+func ReplicationCertificateName(cluster *v1beta1.PostgresCluster) string {
+	return naming.ReplicationClientCertSecret(cluster).Name
+}
+
+// PGBouncerCertificateName returns the name of the cert-manager Certificate CR
+// that issues the PgBouncer frontend leaf.
+func PGBouncerCertificateName(cluster *v1beta1.PostgresCluster) string {
+	return cluster.Name + "-pgbouncer-cert"
+}
+
+// PGBackRestClientCertificateName returns the name of the cert-manager
+// Certificate CR that issues the pgBackRest client leaf.
+func PGBackRestClientCertificateName(cluster *v1beta1.PostgresCluster) string {
+	return cluster.Name + "-pgbackrest-client-cert"
+}
+
+// PGBackRestRepoCertificateName returns the name of the cert-manager
+// Certificate CR that issues the pgBackRest repo host leaf.
+func PGBackRestRepoCertificateName(cluster *v1beta1.PostgresCluster) string {
+	return cluster.Name + "-pgbackrest-repo-cert"
+}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
If Certificates are created in v2.9.0 due to K8SPG-1017, owner ref migration in v3.0.0 is stuck.

**Cause:**
We fixed K8SPG-1017 in v3.0.0 which stops reconciliation of cert-manager Certificate objects if root CA is not managed by cert-manager.

**Solution:**
We need to reconcile these certificates if they exists. So the logic is:
1. Check if root CA is managed by cert-manager.
2. If it's not managed by cert-manager, check if Certificate exists.
3. If certificate exists, reconcile it to update owner references.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
