### PR TITLE
K8SPG-1049: fix restore tolerations

### DIFF
--- a/percona/controller/pgrestore/utils/pgbackrest.go
+++ b/percona/controller/pgrestore/utils/pgbackrest.go
@@ -62,6 +62,14 @@ func (r *PGBackRestRestore) Start(ctx context.Context) error {
 			PostgresClusterDataSource: &v1beta1.PostgresClusterDataSource{},
 		}
 	}
+	if r.pgCluster.Spec.Backups.PGBackRest.Restore.PostgresClusterDataSource == nil {
+		r.pgCluster.Spec.Backups.PGBackRest.Restore.PostgresClusterDataSource = &v1beta1.PostgresClusterDataSource{}
+	}
+	if r.pgCluster.Spec.Backups.PGBackRest.Restore.Tolerations == nil {
+		if jobs := r.pgCluster.Spec.Backups.PGBackRest.Jobs; jobs != nil {
+			r.pgCluster.Spec.Backups.PGBackRest.Restore.Tolerations = jobs.Tolerations
+		}
+	}
 
 	r.pgCluster.Spec.Backups.PGBackRest.Restore.Enabled = new(true)
 	r.pgCluster.Spec.Backups.PGBackRest.Restore.RepoName = ptr.Deref(r.pgRestore.Spec.RepoName, "")

--- a/percona/controller/pgrestore/utils/pgbackrest_test.go
+++ b/percona/controller/pgrestore/utils/pgbackrest_test.go
@@ -1,0 +1,114 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v2 "github.com/percona/percona-postgresql-operator/v2/pkg/apis/pgv2.percona.com/v2"
+	"github.com/percona/percona-postgresql-operator/v2/pkg/apis/upstream.pgv2.percona.com/v1beta1"
+)
+
+func TestPGBackRestRestoreStartTolerations(t *testing.T) {
+	namespace := "test-ns"
+	name := "test-cluster"
+	repoName := "repo1"
+
+	jobTolerations := []corev1.Toleration{{
+		Key:      "backup-jobs",
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoSchedule,
+	}}
+	restoreTolerations := []corev1.Toleration{{
+		Key:      "restore",
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoSchedule,
+	}}
+
+	t.Run("defaults to backup job tolerations", func(t *testing.T) {
+		pgCluster := &v2.PerconaPGCluster{
+			TypeMeta:   metav1.TypeMeta{APIVersion: v2.GroupVersion.String(), Kind: "PerconaPGCluster"},
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: v2.PerconaPGClusterSpec{
+				Backups: v2.Backups{PGBackRest: v2.PGBackRestArchive{
+					Jobs: &v1beta1.BackupJobs{Tolerations: jobTolerations},
+				}},
+			},
+		}
+		postgresCluster := &v1beta1.PostgresCluster{
+			TypeMeta:   metav1.TypeMeta{APIVersion: v1beta1.GroupVersion.String(), Kind: "PostgresCluster"},
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		}
+		pgRestore := &v2.PerconaPGRestore{
+			ObjectMeta: metav1.ObjectMeta{Name: "restore", Namespace: namespace},
+			Spec: v2.PerconaPGRestoreSpec{
+				PGCluster: name,
+				RepoName:  new(repoName),
+			},
+		}
+
+		cl := buildRestoreTestClient(t, pgCluster, postgresCluster)
+		require.NoError(t, NewPGBackRestRestore(cl, pgCluster, pgRestore).Start(t.Context()))
+
+		updated := &v2.PerconaPGCluster{}
+		require.NoError(t, cl.Get(t.Context(), types.NamespacedName{Name: name, Namespace: namespace}, updated))
+		require.Equal(t, jobTolerations, updated.Spec.Backups.PGBackRest.Restore.Tolerations)
+	})
+
+	t.Run("preserves restore tolerations", func(t *testing.T) {
+		pgCluster := &v2.PerconaPGCluster{
+			TypeMeta:   metav1.TypeMeta{APIVersion: v2.GroupVersion.String(), Kind: "PerconaPGCluster"},
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: v2.PerconaPGClusterSpec{
+				Backups: v2.Backups{PGBackRest: v2.PGBackRestArchive{
+					Jobs: &v1beta1.BackupJobs{Tolerations: jobTolerations},
+					Restore: &v1beta1.PGBackRestRestore{
+						PostgresClusterDataSource: &v1beta1.PostgresClusterDataSource{
+							Tolerations: restoreTolerations,
+						},
+					},
+				}},
+			},
+		}
+		postgresCluster := &v1beta1.PostgresCluster{
+			TypeMeta:   metav1.TypeMeta{APIVersion: v1beta1.GroupVersion.String(), Kind: "PostgresCluster"},
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		}
+		pgRestore := &v2.PerconaPGRestore{
+			ObjectMeta: metav1.ObjectMeta{Name: "restore", Namespace: namespace},
+			Spec: v2.PerconaPGRestoreSpec{
+				PGCluster: name,
+				RepoName:  new(repoName),
+			},
+		}
+
+		cl := buildRestoreTestClient(t, pgCluster, postgresCluster)
+		require.NoError(t, NewPGBackRestRestore(cl, pgCluster, pgRestore).Start(t.Context()))
+
+		updated := &v2.PerconaPGCluster{}
+		require.NoError(t, cl.Get(t.Context(), types.NamespacedName{Name: name, Namespace: namespace}, updated))
+		require.Equal(t, restoreTolerations, updated.Spec.Backups.PGBackRest.Restore.Tolerations)
+	})
+}
+
+func buildRestoreTestClient(t *testing.T, pgCluster *v2.PerconaPGCluster,
+	postgresCluster *v1beta1.PostgresCluster,
+) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v2.AddToScheme(scheme))
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pgCluster, postgresCluster).
+		WithStatusSubresource(postgresCluster).
+		Build()
+}


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/K8SPG-1049

**DESCRIPTION**
---
 This PR sets the pgbackrest restore job tolerations to `.spec.backups.pgbackrest.jobs.tolerations` when `.spec.backups.pgbackrest.restore.tolerations` is not specified.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
