### PR TITLE
K8SPG-1058: fix labels for pgupgrade names

### DIFF
--- a/internal/controller/pgupgrade/jobs_test.go
+++ b/internal/controller/pgupgrade/jobs_test.go
@@ -262,6 +262,10 @@ status: {}
 		// Verify the suffix is deterministic (same input always produces same output)
 		longJob2 := reconciler.generateUpgradeJob(ctx, longNameUpgrade, startup, "")
 		assert.Assert(t, longJob.Name == longJob2.Name, "job name should be deterministic: %q vs %q", longJob.Name, longJob2.Name)
+
+		labelValue := longJob.Labels[LabelPGUpgrade]
+		assert.Equal(t, labelValue, longJob.Spec.Template.Labels[LabelPGUpgrade])
+		assert.Assert(t, len(labelValue) <= 63, "label value %q exceeds 63 characters", labelValue)
 	})
 
 	t.Run(feature.PGUpgradeCPUConcurrency+"Enabled", func(t *testing.T) {
@@ -397,7 +401,8 @@ func TestPGUpgradeContainerImage(t *testing.T) {
 	assert.Equal(t, pgUpgradeContainerImage(upgrade), "env-var-pgbackrest")
 
 	assert.NilError(t, yaml.Unmarshal(
-		[]byte(`{ image: spec-image }`), &upgrade.Spec))
+		[]byte(`{ image: spec-image }`), &upgrade.Spec,
+	))
 	assert.Equal(t, pgUpgradeContainerImage(upgrade), "spec-image")
 }
 
@@ -410,5 +415,4 @@ func TestVerifyUpgradeImageValue(t *testing.T) {
 		err := verifyUpgradeImageValue(upgrade)
 		assert.ErrorContains(t, err, "crunchy-upgrade")
 	})
-
 }

--- a/internal/controller/pgupgrade/labels.go
+++ b/internal/controller/pgupgrade/labels.go
@@ -5,6 +5,7 @@
 package pgupgrade
 
 import (
+	"github.com/percona/percona-postgresql-operator/v2/internal/naming"
 	"github.com/percona/percona-postgresql-operator/v2/pkg/apis/upstream.pgv2.percona.com/v1beta1"
 )
 
@@ -35,7 +36,7 @@ const (
 
 func commonLabels(role string, upgrade *v1beta1.PGUpgrade) map[string]string {
 	return map[string]string{
-		LabelPGUpgrade: upgrade.Name,
+		LabelPGUpgrade: naming.SafeDNSUniqueName(upgrade.Name),
 		LabelCluster:   upgrade.Spec.PostgresClusterName,
 		LabelRole:      role,
 	}

--- a/internal/controller/pgupgrade/pgupgrade_controller.go
+++ b/internal/controller/pgupgrade/pgupgrade_controller.go
@@ -255,7 +255,7 @@ func (r *PGUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	var upgradeJob *batchv1.Job
 	for _, job := range world.Jobs {
 		if job.GetLabels()[LabelRole] == pgUpgrade &&
-			job.GetLabels()[LabelPGUpgrade] == upgrade.Name {
+			job.GetLabels()[LabelPGUpgrade] == commonLabels(pgUpgrade, upgrade)[LabelPGUpgrade] {
 			upgradeJob = job
 			break
 		}
@@ -270,7 +270,7 @@ func (r *PGUpgradeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	var removeDataJobsCompleted []*batchv1.Job
 	for _, job := range world.Jobs {
 		if job.GetLabels()[LabelRole] == removeData &&
-			job.GetLabels()[LabelPGUpgrade] == upgrade.Name {
+			job.GetLabels()[LabelPGUpgrade] == commonLabels(removeData, upgrade)[LabelPGUpgrade] {
 			if jobCompleted(job) {
 				removeDataJobsCompleted = append(removeDataJobsCompleted, job)
 			} else if jobFailed(job) {


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/K8SPG-1058

**DESCRIPTION**
---
**Problem:**
*When a pgupgrade name exceeds 63 characters, the generated job name is shortened correctly, but the job labels still contain the full name. This exceeds 63-character limit for label values, preventing the job from being created.*

**Solution:**
*Shorten the pgupgrade label value using the same logic used to generate job names*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
