### PR TITLE
K8SPG-1045: add `operatorProvidedOnly` to the `spec.tls.certManagementPolicy`

### DIFF
--- a/build/crd/percona/generated/pgv2.percona.com_perconapgclusters.yaml
+++ b/build/crd/percona/generated/pgv2.percona.com_perconapgclusters.yaml
@@ -16017,6 +16017,7 @@ spec:
                     enum:
                     - auto
                     - userProvidedOnly
+                    - operatorProvidedOnly
                     type: string
                   certValidityDuration:
                     type: string

--- a/config/crd/bases/pgv2.percona.com_perconapgclusters.yaml
+++ b/config/crd/bases/pgv2.percona.com_perconapgclusters.yaml
@@ -16431,6 +16431,7 @@ spec:
                     enum:
                     - auto
                     - userProvidedOnly
+                    - operatorProvidedOnly
                     type: string
                   certValidityDuration:
                     type: string

--- a/config/crd/bases/upstream.pgv2.percona.com_postgresclusters.yaml
+++ b/config/crd/bases/upstream.pgv2.percona.com_postgresclusters.yaml
@@ -13991,6 +13991,7 @@ spec:
                     enum:
                     - auto
                     - userProvidedOnly
+                    - operatorProvidedOnly
                     type: string
                   certValidityDuration:
                     type: string

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -16632,6 +16632,7 @@ spec:
                     enum:
                     - auto
                     - userProvidedOnly
+                    - operatorProvidedOnly
                     type: string
                   certValidityDuration:
                     type: string
@@ -34900,6 +34901,7 @@ spec:
                     enum:
                     - auto
                     - userProvidedOnly
+                    - operatorProvidedOnly
                     type: string
                   certValidityDuration:
                     type: string

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -16632,6 +16632,7 @@ spec:
                     enum:
                     - auto
                     - userProvidedOnly
+                    - operatorProvidedOnly
                     type: string
                   certValidityDuration:
                     type: string
@@ -34900,6 +34901,7 @@ spec:
                     enum:
                     - auto
                     - userProvidedOnly
+                    - operatorProvidedOnly
                     type: string
                   certValidityDuration:
                     type: string

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -16632,6 +16632,7 @@ spec:
                     enum:
                     - auto
                     - userProvidedOnly
+                    - operatorProvidedOnly
                     type: string
                   certValidityDuration:
                     type: string
@@ -34900,6 +34901,7 @@ spec:
                     enum:
                     - auto
                     - userProvidedOnly
+                    - operatorProvidedOnly
                     type: string
                   certValidityDuration:
                     type: string

--- a/e2e-tests/tests/cert-management-policy/12-recreate-cluster.yaml
+++ b/e2e-tests/tests/cert-management-policy/12-recreate-cluster.yaml
@@ -1,0 +1,25 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      cluster="cert-management-policy"
+
+      kubectl -n "$NAMESPACE" delete perconapgcluster "$cluster" --wait=true
+      kubectl -n "$NAMESPACE" delete postgrescluster "$cluster" --wait=true --ignore-not-found
+      kubectl -n "$NAMESPACE" delete pvc \
+        -l postgres-operator.crunchydata.com/cluster="$cluster" --wait=true
+      kubectl -n "$NAMESPACE" delete secret \
+        -l postgres-operator.crunchydata.com/cluster="$cluster" --wait=true
+
+      get_cr "$cluster" \
+        | yq '.spec.tls.certManagementPolicy = "operatorProvidedOnly"' \
+        | yq '.spec.tls.issuerConf = {"name":"cert-management-policy-ignored-issuer","kind":"ClusterIssuer"}' \
+        | yq '.spec.proxy.pgBouncer.replicas = 1' \
+        | yq '.spec.instances[].replicas = 1' \
+        | kubectl -n "$NAMESPACE" apply -f -
+    timeout: 300

--- a/e2e-tests/tests/cert-management-policy/13-assert.yaml
+++ b/e2e-tests/tests/cert-management-policy/13-assert.yaml
@@ -1,0 +1,21 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 600
+resourceRefs:
+  - apiVersion: pgv2.percona.com/v2
+    kind: PerconaPGCluster
+    name: cert-management-policy
+    ref: cluster
+assertAll:
+  - celExpr: cluster.spec.tls.certManagementPolicy == "operatorProvidedOnly"
+    message: certManagementPolicy should be operatorProvidedOnly
+  - celExpr: cluster.status.conditions.exists(c, c.type == "ReadyForBackup" && c.status == "True" && has(c.observedGeneration) && c.observedGeneration == cluster.metadata.generation)
+    message: ReadyForBackup should be True
+  - celExpr: cluster.status.conditions.exists(c, c.type == "TLSSecretsReady" && c.status == "True" && c.reason == "TLSSecretsFound" && c.message == "certManagementPolicy is operatorProvidedOnly" && has(c.observedGeneration) && c.observedGeneration == cluster.metadata.generation)
+    message: TLSSecretsReady should confirm operatorProvidedOnly
+  - celExpr: cluster.status.pgbouncer.ready == 1 && cluster.status.pgbouncer.size == 1
+    message: PgBouncer should have one ready instance
+  - celExpr: cluster.status.postgres.ready == 1 && cluster.status.postgres.size == 1
+    message: PostgreSQL should have one ready instance
+  - celExpr: cluster.status.state == "ready"
+    message: Cluster state should be ready

--- a/e2e-tests/tests/cert-management-policy/14-verify-operator-provided-only.yaml
+++ b/e2e-tests/tests/cert-management-policy/14-verify-operator-provided-only.yaml
@@ -1,0 +1,82 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      cluster="cert-management-policy"
+
+      verify_secret_data() {
+        local secret="$1"
+        shift
+        for key in "$@"; do
+          local escaped_key="${key//./\\.}"
+          local value
+          value=$(kubectl -n "$NAMESPACE" get secret "$secret" \
+            -o jsonpath="{.data.${escaped_key}}")
+          if [[ -z "$value" ]]; then
+            echo "Secret $secret is missing key: $key" >&2
+            return 1
+          fi
+        done
+      }
+
+      verify_secret_data "${cluster}-cluster-ca-cert" root.crt root.key
+      verify_secret_data "${cluster}-cluster-cert" tls.crt tls.key ca.crt
+      verify_secret_data "${cluster}-replication-cert" tls.crt tls.key ca.crt
+      verify_secret_data "${cluster}-pgbackrest" pgbackrest.ca-roots pgbackrest-client.crt pgbackrest-client.key
+      verify_secret_data "${cluster}-pgbouncer" pgbouncer-frontend.ca-roots pgbouncer-frontend.crt pgbouncer-frontend.key
+
+      for secret in \
+        "${cluster}-cluster-ca-cert" \
+        "${cluster}-cluster-cert" \
+        "${cluster}-replication-cert" \
+        "${cluster}-pgbackrest" \
+        "${cluster}-pgbouncer"; do
+        annotation=$(kubectl -n "$NAMESPACE" get secret "$secret" \
+          -o jsonpath='{.metadata.annotations.cert-manager\.io/certificate-name}' 2>/dev/null || true)
+        if [[ -n "$annotation" ]]; then
+          echo "Secret $secret is unexpectedly managed by cert-manager" >&2
+          exit 1
+        fi
+      done
+
+      instance_sts=$(kubectl -n "$NAMESPACE" get sts \
+        -l postgres-operator.crunchydata.com/cluster="$cluster",postgres-operator.crunchydata.com/instance-set=instance1 \
+        -o jsonpath='{.items[*].metadata.name}')
+      if [[ -z "$instance_sts" ]]; then
+        echo "No PostgreSQL instance StatefulSet found for $cluster" >&2
+        exit 1
+      fi
+      for sts_name in $instance_sts; do
+        verify_secret_data "${sts_name}-certs" dns.crt dns.key patroni.ca-roots patroni.crt-combined
+        annotation=$(kubectl -n "$NAMESPACE" get secret "${sts_name}-certs" \
+          -o jsonpath='{.metadata.annotations.cert-manager\.io/certificate-name}' 2>/dev/null || true)
+        if [[ -n "$annotation" ]]; then
+          echo "Instance Secret ${sts_name}-certs is unexpectedly managed by cert-manager" >&2
+          exit 1
+        fi
+      done
+
+      certificates=$(kubectl -n "$NAMESPACE" get certificate \
+        -l postgres-operator.crunchydata.com/cluster="$cluster" \
+        -o name)
+      if [[ -n "$certificates" ]]; then
+        echo "Certificate resources were generated in operatorProvidedOnly mode: $certificates" >&2
+        exit 1
+      fi
+
+      issuers=$(kubectl -n "$NAMESPACE" get issuer -o json \
+        | jq -r '.items[].metadata.name | select(startswith("cert-management-policy-"))')
+      if [[ -n "$issuers" ]]; then
+        echo "Issuer resources were generated in operatorProvidedOnly mode: $issuers" >&2
+        exit 1
+      fi
+
+      if kubectl get clusterissuer cert-management-policy-ignored-issuer >/dev/null 2>&1; then
+        echo "operatorProvidedOnly created the ClusterIssuer from issuerConf" >&2
+        exit 1
+      fi
+
+    timeout: 300

--- a/internal/controller/postgrescluster/instance.go
+++ b/internal/controller/postgrescluster/instance.go
@@ -1610,7 +1610,6 @@ func (r *Reconciler) reconcileInstanceCertificates(
 			}
 			return existing, nil
 		}
-
 		certManagerManaged, err := r.isRootCACertManagerManaged(ctx, cluster)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to check if cert-manager manages root CA")
@@ -1623,7 +1622,7 @@ func (r *Reconciler) reconcileInstanceCertificates(
 		// cluster certificates are not managed by cert-manager
 		// but Certificate object exists due to the bug described in K8SPG-1017
 		// we need to reconcile them anyway to update ownerRef for K8SPG-1007.
-		if cert := certmanager.InstanceCertificateName(instance.Name); r.shouldReconcileCertManagerCertificate(ctx, cluster.Namespace, cert) {
+		if cert := certmanager.InstanceCertificateName(instance.Name); r.shouldReconcileCertManagerCertificate(ctx, cluster, cert) {
 			_, err := r.reconcileCertManagerInstanceCertificates(ctx, cluster, spec, instance, rootCertificateAuth)
 			if err != nil {
 				logging.FromContext(ctx).Error(err, "failed to reconcile Certificate", "name", cert)

--- a/internal/controller/postgrescluster/patroni.go
+++ b/internal/controller/postgrescluster/patroni.go
@@ -395,7 +395,6 @@ func (r *Reconciler) reconcileReplicationSecret(
 		}
 		return secret, nil
 	}
-
 	certManagerManaged, err := r.isRootCACertManagerManaged(ctx, cluster)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to check if cert-manager manages root CA")
@@ -408,7 +407,7 @@ func (r *Reconciler) reconcileReplicationSecret(
 	// cluster certificates are not managed by cert-manager
 	// but Certificate object exists due to the bug described in K8SPG-1017
 	// we need to reconcile them anyway to update ownerRef for K8SPG-1007.
-	if cert := certmanager.ReplicationCertificateName(cluster); r.shouldReconcileCertManagerCertificate(ctx, cluster.Namespace, cert) {
+	if cert := certmanager.ReplicationCertificateName(cluster); r.shouldReconcileCertManagerCertificate(ctx, cluster, cert) {
 		_, err := r.reconcileCertManagerReplicationSecret(ctx, cluster)
 		if err != nil {
 			logging.FromContext(ctx).Error(err, "failed to reconcile Certificate", "name", cert)

--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -2329,7 +2329,7 @@ func (r *Reconciler) reconcilePGBackRestSecret(ctx context.Context,
 			// cluster certificates are not managed by cert-manager
 			// but Certificate object exists due to the bug described in K8SPG-1017
 			// we need to reconcile them anyway to update ownerRef for K8SPG-1007.
-			if cert := certmanager.PGBackRestClientCertificateName(cluster); r.shouldReconcileCertManagerCertificate(ctx, cluster.Namespace, cert) {
+			if cert := certmanager.PGBackRestClientCertificateName(cluster); r.shouldReconcileCertManagerCertificate(ctx, cluster, cert) {
 				err := r.reconcileCertManagerPGBackRestSecret(ctx, cluster, repoHost, rootCA, existing, intent)
 				if err != nil {
 					logging.FromContext(ctx).Error(err, "failed to reconcile Certificate", "name", cert)

--- a/internal/controller/postgrescluster/pgbouncer.go
+++ b/internal/controller/postgrescluster/pgbouncer.go
@@ -310,7 +310,7 @@ func (r *Reconciler) reconcilePGBouncerSecret(
 			// cluster certificates are not managed by cert-manager
 			// but Certificate object exists due to the bug described in K8SPG-1017
 			// we need to reconcile them anyway to update ownerRef for K8SPG-1007.
-			if cert := certmanager.PGBouncerCertificateName(cluster); r.shouldReconcileCertManagerCertificate(ctx, cluster.Namespace, cert) {
+			if cert := certmanager.PGBouncerCertificateName(cluster); r.shouldReconcileCertManagerCertificate(ctx, cluster, cert) {
 				_, err := r.reconcileCertManagerPGBouncerSecret(ctx, cluster, service)
 				if err != nil {
 					logging.FromContext(ctx).Error(err, "failed to reconcile Certificate", "name", cert)

--- a/internal/controller/postgrescluster/pki.go
+++ b/internal/controller/postgrescluster/pki.go
@@ -160,6 +160,7 @@ func (r *Reconciler) reconcileRootCertificate(
 ) (
 	*pki.RootCertificateAuthority, error,
 ) {
+	policy := cluster.Spec.TLS.GetCertManagementPolicy()
 	mode, err := certmanager.ResolveIssuerMode(ctx, r.Client, cluster)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to resolve issuer mode")
@@ -207,7 +208,7 @@ func (r *Reconciler) reconcileRootCertificate(
 		}
 	}
 
-	if cluster.Spec.TLS.GetCertManagementPolicy() == v1beta1.CertManagementUserProvidedOnly {
+	if policy == v1beta1.CertManagementUserProvidedOnly {
 		if err != nil {
 			return nil, errors.Wrap(err, "get user-provided root CA secret")
 		}
@@ -226,7 +227,7 @@ func (r *Reconciler) reconcileRootCertificate(
 	}
 	// If the secret is managed by cert-manager, parse it using cert-manager key names
 	// (tls.crt/tls.key) and return without overwriting the secret with internal PKI.
-	if err == nil && existing.Annotations["cert-manager.io/certificate-name"] != "" {
+	if policy == v1beta1.CertManagementAuto && err == nil && existing.Annotations["cert-manager.io/certificate-name"] != "" {
 		if _, certManagerErr := r.reconcileCertManagerRootCertificate(ctx, cluster); certManagerErr != nil {
 			return nil, certManagerErr
 		}
@@ -309,12 +310,11 @@ func (r *Reconciler) reconcileCertManagerRootCertificate(
 	ctx context.Context, cluster *v1beta1.PostgresCluster,
 ) (*corev1.Secret, error) {
 	log := logging.FromContext(ctx)
-	installed, err := r.isCertManagerInstalled(ctx, cluster.Namespace)
+	useCertManager, err := r.shouldUseCertManager(ctx, cluster)
 	if err != nil {
-		return nil, errors.Wrap(err, "error checking if cert-manager is installed")
+		return nil, errors.Wrap(err, "error deciding whether to use cert-manager")
 	}
-	if !installed {
-		log.Info("cert-manager is not installed")
+	if !useCertManager {
 		return nil, nil
 	}
 	c := r.CertManagerCtrlFunc(r.Client, r.Scheme, false)
@@ -385,7 +385,7 @@ func (r *Reconciler) reconcileClusterCertificate(
 	// cluster certificates are not managed by cert-manager
 	// but Certificate object exists due to the bug described in K8SPG-1017
 	// we need to reconcile them anyway to update ownerRef for K8SPG-1007.
-	if cert := certmanager.ClusterCertificateName(cluster); r.shouldReconcileCertManagerCertificate(ctx, cluster.Namespace, cert) {
+	if cert := certmanager.ClusterCertificateName(cluster); r.shouldReconcileCertManagerCertificate(ctx, cluster, cert) {
 		_, err := r.reconcileCertManagerClusterCertificate(ctx, cluster, primaryService, replicaService)
 		if err != nil {
 			logging.FromContext(ctx).Error(err, "failed to reconcile Certificate", "name", cert)
@@ -541,11 +541,13 @@ func (r *Reconciler) reconcileCertManagerClusterCertificate(
 // shouldReconcileCertManagerCertificate reports whether a stale cert-manager
 // Certificate CR exists for the cluster and should be reconciled to update
 // its ownerRef (K8SPG-1007 recovery for Certificates left behind by the
-// K8SPG-1017 bug). Returns false when cert-manager is not installed or the
-// Certificate CR does not exist.
-func (r *Reconciler) shouldReconcileCertManagerCertificate(ctx context.Context, namespace, certName string) bool {
-	installed, err := r.isCertManagerInstalled(ctx, namespace)
-	if err != nil || !installed {
+// K8SPG-1017 bug). Returns false when policy disables cert-manager,
+// cert-manager is unavailable, or the Certificate CR does not exist.
+func (r *Reconciler) shouldReconcileCertManagerCertificate(
+	ctx context.Context, cluster *v1beta1.PostgresCluster, certName string,
+) bool {
+	useCertManager, err := r.shouldUseCertManager(ctx, cluster)
+	if err != nil || !useCertManager {
 		return false
 	}
 
@@ -553,7 +555,7 @@ func (r *Reconciler) shouldReconcileCertManagerCertificate(ctx context.Context, 
 	// the intent (no mutating cert-manager calls happen on this path).
 	c := r.CertManagerCtrlFunc(r.Client, r.Scheme, true /* dry run */)
 
-	exists, err := c.CertificateExists(ctx, namespace, certName)
+	exists, err := c.CertificateExists(ctx, cluster.Namespace, certName)
 
 	return err == nil && exists
 }
@@ -568,19 +570,19 @@ func (r *Reconciler) isRootCACertManagerManaged(ctx context.Context, cluster *v1
 		return false, errors.Wrap(err, "failed to resolve issuer mode")
 	}
 
-	installed, err := r.isCertManagerInstalled(ctx, cluster.Namespace)
+	useCertManager, err := r.shouldUseCertManager(ctx, cluster)
 	if err != nil {
 		return false, err
 	}
 
 	if mode != certmanager.IssuerModeManagedNamespaced {
-		if !installed {
+		if !useCertManager {
 			return false, errors.New("cert-manager is required when spec.tls.issuerConf is set")
 		}
 		return true, nil
 	}
 
-	if !installed {
+	if !useCertManager {
 		return false, nil
 	}
 
@@ -596,12 +598,17 @@ func (r *Reconciler) isRootCACertManagerManaged(ctx context.Context, cluster *v1
 	return rootSecret.Annotations["cert-manager.io/certificate-name"] != "", nil
 }
 
-func (r *Reconciler) isCertManagerInstalled(ctx context.Context, ns string) (bool, error) {
+func (r *Reconciler) shouldUseCertManager(
+	ctx context.Context, cluster *v1beta1.PostgresCluster,
+) (bool, error) {
+	if cluster.Spec.TLS.GetCertManagementPolicy() != v1beta1.CertManagementAuto {
+		return false, nil
+	}
 	if r.RestConfig == nil {
 		return false, nil
 	}
 	c := r.CertManagerCtrlFunc(r.Client, r.Scheme, true)
-	err := c.Check(ctx, r.RestConfig, ns)
+	err := c.Check(ctx, r.RestConfig, cluster.Namespace)
 	if err != nil {
 		switch {
 		case errors.Is(err, certmanager.ErrCertManagerNotFound):

--- a/internal/controller/postgrescluster/pki_test.go
+++ b/internal/controller/postgrescluster/pki_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/percona/percona-postgresql-operator/v2/internal/naming"
+	"github.com/percona/percona-postgresql-operator/v2/internal/pgbackrest"
 	"github.com/percona/percona-postgresql-operator/v2/internal/pgbouncer"
 	"github.com/percona/percona-postgresql-operator/v2/internal/pki"
 	"github.com/percona/percona-postgresql-operator/v2/internal/testing/require"
@@ -61,6 +62,22 @@ func TestReconcileTLSCondition(t *testing.T) {
 		assert.Equal(t, condition.Reason, "TLSSecretsFound")
 		assert.Equal(t, condition.Message, "certManagementPolicy is auto")
 		assert.Equal(t, condition.ObservedGeneration, int64(7))
+	})
+
+	t.Run("operator-provided certificate management", func(t *testing.T) {
+		cluster := testCluster()
+		cluster.Generation = 8
+		cluster.Spec.TLS = &v1beta1.TLSSpec{
+			CertManagementPolicy: v1beta1.CertManagementOperatorProvidedOnly,
+		}
+
+		r := &Reconciler{}
+		assert.NilError(t, r.reconcileTLSCondition(t.Context(), cluster))
+
+		condition := condition(t, cluster, metav1.ConditionTrue)
+		assert.Equal(t, condition.Reason, "TLSSecretsFound")
+		assert.Equal(t, condition.Message, "certManagementPolicy is operatorProvidedOnly")
+		assert.Equal(t, condition.ObservedGeneration, int64(8))
 	})
 
 	t.Run("missing user-provided secrets", func(t *testing.T) {
@@ -554,6 +571,7 @@ func TestReconcileCerts(t *testing.T) {
 type mockCertManagerController struct{}
 
 func (m *mockCertManagerController) Check(context.Context, *rest.Config, string) error { return nil }
+
 func (m *mockCertManagerController) CertificateExists(context.Context, string, string) (bool, error) {
 	return false, nil
 }
@@ -596,6 +614,56 @@ func (m *mockCertManagerController) ApplyPGBackRestRepoCertificate(context.Conte
 
 func mockCertManagerCtrlFunc(_ client.Client, _ *runtime.Scheme, _ bool) certmanager.Controller {
 	return &mockCertManagerController{}
+}
+
+type rejectingCertManagerController struct{}
+
+func (rejectingCertManagerController) Check(context.Context, *rest.Config, string) error {
+	panic("unexpected cert-manager availability check")
+}
+
+func (rejectingCertManagerController) CertificateExists(context.Context, string, string) (bool, error) {
+	panic("unexpected cert-manager Certificate check")
+}
+
+func (rejectingCertManagerController) ApplyIssuer(context.Context, *v1beta1.PostgresCluster) error {
+	panic("unexpected cert-manager issuer apply")
+}
+
+func (rejectingCertManagerController) ApplyCAIssuer(context.Context, *v1beta1.PostgresCluster) error {
+	panic("unexpected cert-manager CA issuer apply")
+}
+
+func (rejectingCertManagerController) ApplyCACertificate(context.Context, *v1beta1.PostgresCluster) error {
+	panic("unexpected cert-manager CA certificate apply")
+}
+
+func (rejectingCertManagerController) ApplyClusterCertificate(context.Context, *v1beta1.PostgresCluster, []string) error {
+	panic("unexpected cert-manager cluster certificate apply")
+}
+
+func (rejectingCertManagerController) ApplyInstanceCertificate(context.Context, *v1beta1.PostgresCluster, string, []string) error {
+	panic("unexpected cert-manager instance certificate apply")
+}
+
+func (rejectingCertManagerController) ApplyPGBouncerCertificate(context.Context, *v1beta1.PostgresCluster, []string) error {
+	panic("unexpected cert-manager PgBouncer certificate apply")
+}
+
+func (rejectingCertManagerController) ApplyReplicationCertificate(context.Context, *v1beta1.PostgresCluster) error {
+	panic("unexpected cert-manager replication certificate apply")
+}
+
+func (rejectingCertManagerController) ApplyPGBackRestClientCertificate(context.Context, *v1beta1.PostgresCluster) error {
+	panic("unexpected cert-manager pgBackRest client certificate apply")
+}
+
+func (rejectingCertManagerController) ApplyPGBackRestRepoCertificate(context.Context, *v1beta1.PostgresCluster, []string) error {
+	panic("unexpected cert-manager pgBackRest repository certificate apply")
+}
+
+func rejectingCertManagerCtrlFunc(_ client.Client, _ *runtime.Scheme, _ bool) certmanager.Controller {
+	return rejectingCertManagerController{}
 }
 
 // recoveryCertManagerController reports the cert-manager Certificate object as
@@ -737,13 +805,13 @@ func TestUpgradeCertManagerDoesNotTakeOverInternalPKI(t *testing.T) {
 
 	t.Run("shouldReconcileCertManagerCertificate", func(t *testing.T) {
 		t.Run("returns false when cert-manager is not installed", func(t *testing.T) {
-			// RestConfig is nil, so isCertManagerInstalled short-circuits to false.
+			// RestConfig is nil, so shouldUseCertManager short-circuits to false.
 			r := &Reconciler{
 				Client:              tClient,
 				Owner:               ControllerName,
 				CertManagerCtrlFunc: mockCertManagerCtrlFunc,
 			}
-			assert.Assert(t, !r.shouldReconcileCertManagerCertificate(ctx, namespace, "any-cert"))
+			assert.Assert(t, !r.shouldReconcileCertManagerCertificate(ctx, cluster, "any-cert"))
 		})
 
 		t.Run("returns false when cert-manager Certificate does not exist", func(t *testing.T) {
@@ -754,7 +822,7 @@ func TestUpgradeCertManagerDoesNotTakeOverInternalPKI(t *testing.T) {
 				CertManagerCtrlFunc: mockCertManagerCtrlFunc,
 				RestConfig:          &rest.Config{},
 			}
-			assert.Assert(t, !r.shouldReconcileCertManagerCertificate(ctx, namespace, "missing-cert"))
+			assert.Assert(t, !r.shouldReconcileCertManagerCertificate(ctx, cluster, "missing-cert"))
 		})
 
 		t.Run("returns true when cert-manager is installed and Certificate exists", func(t *testing.T) {
@@ -766,7 +834,7 @@ func TestUpgradeCertManagerDoesNotTakeOverInternalPKI(t *testing.T) {
 				},
 				RestConfig: &rest.Config{},
 			}
-			assert.Assert(t, r.shouldReconcileCertManagerCertificate(ctx, namespace, "any-cert"))
+			assert.Assert(t, r.shouldReconcileCertManagerCertificate(ctx, cluster, "any-cert"))
 		})
 	})
 
@@ -969,7 +1037,7 @@ func getCertFromSecret(
 
 // installedCertManagerController reports cert-manager as installed and lets
 // every Apply* call succeed as a no-op — used for issuer-mode
-// tests that only need isCertManagerInstalled to return true, not real
+// tests that only need shouldUseCertManager to return true, not real
 // Issuer/Certificate object creation (envtest has no cert-manager CRDs).
 type installedCertManagerController struct{}
 
@@ -1027,6 +1095,103 @@ func TestIssuerModeAwareness(t *testing.T) {
 	ctx := t.Context()
 	namespace := require.Namespace(t, tClient).Name
 
+	t.Run("non-auto policies skip cert-manager availability checks", func(t *testing.T) {
+		for _, policy := range []v1beta1.CertManagementPolicy{
+			v1beta1.CertManagementUserProvidedOnly,
+			v1beta1.CertManagementOperatorProvidedOnly,
+		} {
+			cluster := testCluster()
+			cluster.Namespace = namespace
+			cluster.Spec.TLS = &v1beta1.TLSSpec{CertManagementPolicy: policy}
+			r := &Reconciler{
+				CertManagerCtrlFunc: rejectingCertManagerCtrlFunc,
+				RestConfig:          &rest.Config{},
+			}
+
+			useCertManager, err := r.shouldUseCertManager(ctx, cluster)
+			assert.NilError(t, err)
+			assert.Assert(t, !useCertManager, string(policy))
+		}
+	})
+
+	t.Run("operatorProvidedOnly uses internal PKI", func(t *testing.T) {
+		cluster := testCluster()
+		cluster.Name = "operator-provided-only"
+		cluster.Namespace = namespace
+		cluster.Spec.TLS = &v1beta1.TLSSpec{
+			CertManagementPolicy: v1beta1.CertManagementOperatorProvidedOnly,
+			IssuerConf: &cmmeta.IssuerReference{
+				Name: "ignored-external-issuer", Kind: "VaultClusterIssuer",
+			},
+		}
+		assert.NilError(t, tClient.Create(ctx, cluster))
+
+		r := &Reconciler{
+			Client:              tClient,
+			Owner:               ControllerName,
+			CertManagerCtrlFunc: rejectingCertManagerCtrlFunc,
+			RestConfig:          &rest.Config{},
+		}
+
+		root, err := r.reconcileRootCertificate(ctx, cluster)
+		assert.NilError(t, err)
+		assert.Assert(t, root != nil)
+
+		primaryService := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace, Name: cluster.Name + "-primary",
+		}}
+		replicaService := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace, Name: cluster.Name + "-replicas",
+		}}
+		clusterProjection, err := r.reconcileClusterCertificate(ctx, root, cluster, primaryService, replicaService)
+		assert.NilError(t, err)
+		assert.Equal(t, clusterProjection.Name, naming.PostgresTLSSecret(cluster).Name)
+
+		instance := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace, Name: cluster.Name + "-instance1-abcd",
+		}}
+		instance.Spec.ServiceName = cluster.Name + "-pods"
+		instanceSecret, err := r.reconcileInstanceCertificates(ctx, cluster, &cluster.Spec.InstanceSets[0], instance, root)
+		assert.NilError(t, err)
+		assert.Assert(t, len(instanceSecret.Data["dns.crt"]) > 0)
+
+		replicationSecret, err := r.reconcileReplicationSecret(ctx, cluster, root)
+		assert.NilError(t, err)
+		assert.Assert(t, len(replicationSecret.Data[naming.ReplicationCert]) > 0)
+
+		pgbouncerService := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace, Name: cluster.Name + "-pgbouncer",
+		}}
+		pgbouncerSecret, err := r.reconcilePGBouncerSecret(ctx, cluster, root, pgbouncerService)
+		assert.NilError(t, err)
+		assert.Assert(t, len(pgbouncerSecret.Data[pgbouncer.CertFrontendSecretKey]) > 0)
+
+		repoHost := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace, Name: cluster.Name + "-repo-host",
+		}}
+		repoHost.Spec.ServiceName = cluster.Name + "-pods"
+		assert.NilError(t, r.reconcilePGBackRestSecret(ctx, cluster, repoHost, root))
+		pgBackRestSecret := &corev1.Secret{ObjectMeta: naming.PGBackRestSecret(cluster)}
+		assert.NilError(t, tClient.Get(ctx, client.ObjectKeyFromObject(pgBackRestSecret), pgBackRestSecret))
+		for _, key := range []string{
+			pgbackrest.CertAuthoritySecretKey,
+			pgbackrest.CertClientSecretKey,
+			pgbackrest.CertClientPrivateKeySecretKey,
+			pgbackrest.CertRepoSecretKey,
+			pgbackrest.CertRepoPrivateKeySecretKey,
+		} {
+			assert.Assert(t, len(pgBackRestSecret.Data[key]) > 0, key)
+		}
+
+		custom := cluster.DeepCopy()
+		custom.Spec.CustomTLSSecret = &corev1.SecretProjection{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "custom-postgres-tls"},
+		}
+		projection, err := r.reconcileClusterCertificate(ctx, root, custom, primaryService, replicaService)
+		assert.NilError(t, err)
+		assert.Equal(t, projection.Name, "custom-postgres-tls")
+	})
+
 	t.Run("reconcileRootCertificate returns nil for external issuer", func(t *testing.T) {
 		cluster := testCluster()
 		cluster.Name = "external-root-cert"
@@ -1060,7 +1225,7 @@ func TestIssuerModeAwareness(t *testing.T) {
 			Client:              tClient,
 			Owner:               ControllerName,
 			CertManagerCtrlFunc: mockCertManagerCtrlFunc,
-			RestConfig:          nil, // isCertManagerInstalled short-circuits to false
+			RestConfig:          nil, // shouldUseCertManager short-circuits to false
 		}
 
 		_, err := r.isRootCACertManagerManaged(ctx, cluster)

--- a/internal/pgbouncer/reconcile_test.go
+++ b/internal/pgbouncer/reconcile_test.go
@@ -234,6 +234,16 @@ func TestSecretCertManagementPolicy(t *testing.T) {
 			expectTLSData: true,
 		},
 		{
+			name:          "operator provided only generates TLS data in the operator Secret",
+			policy:        v1beta1.CertManagementOperatorProvidedOnly,
+			expectTLSData: true,
+		},
+		{
+			name:      "operator provided only with custom TLS does not generate TLS data",
+			policy:    v1beta1.CertManagementOperatorProvidedOnly,
+			customTLS: true,
+		},
+		{
 			name:      "auto with custom TLS leaves TLS data out of the operator Secret",
 			policy:    v1beta1.CertManagementAuto,
 			customTLS: true,

--- a/percona/certmanager/certmanager.go
+++ b/percona/certmanager/certmanager.go
@@ -76,6 +76,11 @@ func issuerConf(cluster *v1beta1.PostgresCluster) *cmmeta.IssuerReference {
 
 // ResolveIssuerMode determines how the operator should handle cluster.Spec.TLS.IssuerConf.
 func ResolveIssuerMode(ctx context.Context, cl client.Client, cluster *v1beta1.PostgresCluster) (IssuerMode, error) {
+	// Only auto uses cert-manager
+	if cluster.Spec.TLS.GetCertManagementPolicy() != v1beta1.CertManagementAuto {
+		return IssuerModeManagedNamespaced, nil
+	}
+
 	ic := issuerConf(cluster)
 	if ic == nil {
 		return IssuerModeManagedNamespaced, nil

--- a/percona/certmanager/certmanager_test.go
+++ b/percona/certmanager/certmanager_test.go
@@ -1250,6 +1250,29 @@ func TestCertManagerNamespace(t *testing.T) {
 }
 
 func TestResolveIssuerMode(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		policy v1beta1.CertManagementPolicy
+	}{
+		{name: "userProvidedOnly ignores issuerConf", policy: v1beta1.CertManagementUserProvidedOnly},
+		{name: "operatorProvidedOnly ignores issuerConf", policy: v1beta1.CertManagementOperatorProvidedOnly},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := testCluster()
+			cluster.Spec.TLS = &v1beta1.TLSSpec{
+				CertManagementPolicy: tt.policy,
+				IssuerConf: &cmmeta.IssuerReference{
+					Name: "shared-issuer", Kind: v1.ClusterIssuerKind,
+				},
+			}
+			cl := &forbiddenGetClient{Client: setupFakeClient(t, cluster)}
+
+			mode, err := ResolveIssuerMode(t.Context(), cl, cluster)
+			require.NoError(t, err)
+			assert.Equal(t, IssuerModeManagedNamespaced, mode)
+		})
+	}
+
 	t.Run("nil TLS returns managed namespaced", func(t *testing.T) {
 		cluster := testCluster()
 		cl := setupFakeClient(t, cluster)

--- a/pkg/apis/upstream.pgv2.percona.com/v1beta1/postgrescluster_types.go
+++ b/pkg/apis/upstream.pgv2.percona.com/v1beta1/postgrescluster_types.go
@@ -319,7 +319,7 @@ type TLSSpec struct {
 	// +optional
 	PGBackRestCertValidityDuration *metav1.Duration `json:"pgBackRestCertValidityDuration,omitempty"`
 	// +kubebuilder:default=auto
-	// +kubebuilder:validation:Enum={auto,userProvidedOnly}
+	// +kubebuilder:validation:Enum={auto,userProvidedOnly,operatorProvidedOnly}
 	CertManagementPolicy CertManagementPolicy `json:"certManagementPolicy,omitempty"`
 	// +optional
 	IssuerConf *cmmeta.IssuerReference `json:"issuerConf,omitempty"`
@@ -335,8 +335,9 @@ func (s *TLSSpec) GetCertManagementPolicy() CertManagementPolicy {
 type CertManagementPolicy string
 
 const (
-	CertManagementAuto             CertManagementPolicy = "auto"
-	CertManagementUserProvidedOnly CertManagementPolicy = "userProvidedOnly"
+	CertManagementAuto                 CertManagementPolicy = "auto"
+	CertManagementUserProvidedOnly     CertManagementPolicy = "userProvidedOnly"
+	CertManagementOperatorProvidedOnly CertManagementPolicy = "operatorProvidedOnly"
 )
 
 const (


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/K8SPG-1045

**DESCRIPTION**
---
This PR adds the `operatorProvidedOnly` value to `spec.tls.certManagementPolicy`.

When used, the operator generates and manages TLS certificates without cert-manager

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
