### PR TITLE
K8SPG-851: add logcollector to release_versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -329,7 +329,7 @@ update-version:
 PG_VER ?= $(shell grep -o "postgresVersion: .*" deploy/cr.yaml|grep -oE "[0-9]+")
 CERT_MANAGER_VER := $(shell grep -Eo "cert-manager v.*" go.mod|grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")
 include e2e-tests/release_versions
-release:  generate license
+release: generate license
 	$(SED) -i "/CERT_MANAGER_VER/s/CERT_MANAGER_VER=\".*/CERT_MANAGER_VER=\"$(CERT_MANAGER_VER)\"/" e2e-tests/functions
 	$(SED) -i \
 		-e "/^spec:/,/^  crVersion:/{s/crVersion: .*/crVersion: $(VERSION)/}" \

--- a/Makefile
+++ b/Makefile
@@ -329,7 +329,7 @@ update-version:
 PG_VER ?= $(shell grep -o "postgresVersion: .*" deploy/cr.yaml|grep -oE "[0-9]+")
 CERT_MANAGER_VER := $(shell grep -Eo "cert-manager v.*" go.mod|grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")
 include e2e-tests/release_versions
-release: generate license
+release:  generate license
 	$(SED) -i "/CERT_MANAGER_VER/s/CERT_MANAGER_VER=\".*/CERT_MANAGER_VER=\"$(CERT_MANAGER_VER)\"/" e2e-tests/functions
 	$(SED) -i \
 		-e "/^spec:/,/^  crVersion:/{s/crVersion: .*/crVersion: $(VERSION)/}" \
@@ -338,7 +338,8 @@ release: generate license
 		-e "/^    pgBouncer:/,/^      image:/{s#image: .*#image: $(REGISTRY_NAME_FULL)$(IMAGE_PGBOUNCER18)#}" \
 		-e "/^    pgbackrest:/,/^      image:/{s#image: .*#image: $(REGISTRY_NAME_FULL)$(IMAGE_BACKREST18)#}" \
 		-e "/extensions:/,/image:/{s#image: .*#image: $(REGISTRY_NAME_FULL)$(IMAGE_OPERATOR)#}" \
-		-e "/^  pmm:/,/^    image:/{s#image: .*#image: $(REGISTRY_NAME_FULL)$(IMAGE_PMM_CLIENT)#}" deploy/cr.yaml
+		-e "/^  pmm:/,/^    image:/{s#image: .*#image: $(REGISTRY_NAME_FULL)$(IMAGE_PMM_CLIENT)#}" \
+		-e "/^  logcollector:/,/^    image:/{s#image: .*#image: $(REGISTRY_NAME_FULL)$(IMAGE_LOGCOLLECTOR)#}" deploy/cr.yaml
 	$(SED) -i -r "/Version *= \"[0-9]+\.[0-9]+\.[0-9]+\"$$/ s/[0-9]+\.[0-9]+\.[0-9]+/$(VERSION)/" pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
 	$(SED) -i \
        -e "/^spec:/,/^  image:/{s#image: .*#image: $(REGISTRY_NAME_FULL)$(IMAGE_UPGRADE)#}" \
@@ -366,6 +367,7 @@ after-release: update-version generate after-release-versions
 		-e "/^    pgBouncer:/,/^      image:/{s#image: .*#image: $(REGISTRY_NAME_FULL)perconalab/percona-postgresql-operator:main-pgbouncer$(PG_VER)#}" \
 		-e "/^    pgbackrest:/,/^      image:/{s#image: .*#image: $(REGISTRY_NAME_FULL)perconalab/percona-postgresql-operator:main-pgbackrest$(PG_VER)#}" \
 		-e "/extensions:/,/image:/{s#image: .*#image: $(REGISTRY_NAME_FULL)perconalab/percona-postgresql-operator:main#}" \
+		-e "/^  logcollector:/,/image:/{s#image: .*#image: $(REGISTRY_NAME_FULL)perconalab/fluentbit:main-logcollector#}" \
 		-e "/^  pmm:/,/^    image:/{s#image: .*#image: $(REGISTRY_NAME_FULL)perconalab/pmm-client:3-dev-latest#}" deploy/cr.yaml percona/controller/testdata/sidecar-resources-cr.yaml
 	$(SED) -i -r "/Version *= \"[0-9]+\.[0-9]+\.[0-9]+\"$$/ s/[0-9]+\.[0-9]+\.[0-9]+/$(NEXT_VER)/" pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
 	$(SED) -i \
@@ -408,4 +410,5 @@ after-release-versions:
 		-e "s#^IMAGE_UPGRADE=.*#IMAGE_UPGRADE=$(IMAGE_TAG_BASE):main-upgrade#" \
 		-e "s#^IMAGE_PMM_CLIENT=.*#IMAGE_PMM_CLIENT=perconalab/pmm-client:3-dev-latest#" \
 		-e "s#^IMAGE_PMM_SERVER=.*#IMAGE_PMM_SERVER=perconalab/pmm-server:3-dev-latest#" \
+		-e "s#^IMAGE_LOGCOLLECTOR=.*#IMAGE_LOGCOLLECTOR=perconalab/fluentbit:main-logcollector#" \
 		e2e-tests/release_versions

--- a/e2e-tests/release_versions
+++ b/e2e-tests/release_versions
@@ -26,7 +26,7 @@ IMAGE_POSTGIS18=perconalab/percona-postgresql-operator:main-ppg18-postgres-gis
 IMAGE_BACKREST18=perconalab/percona-postgresql-operator:main-pgbackrest18
 
 IMAGE_UPGRADE=perconalab/percona-postgresql-operator:main-upgrade
-IMAGE_LOGCOLLECTOR=perconalab/fluentbit:main-logcollector
+IMAGE_LOGCOLLECTOR=tratata/fluentbit:main-logcollector
 
 IMAGE_PMM_CLIENT=perconalab/pmm-client:3-dev-latest
 IMAGE_PMM_SERVER=perconalab/pmm-server:3-dev-latest

--- a/e2e-tests/release_versions
+++ b/e2e-tests/release_versions
@@ -26,6 +26,7 @@ IMAGE_POSTGIS18=perconalab/percona-postgresql-operator:main-ppg18-postgres-gis
 IMAGE_BACKREST18=perconalab/percona-postgresql-operator:main-pgbackrest18
 
 IMAGE_UPGRADE=perconalab/percona-postgresql-operator:main-upgrade
+IMAGE_LOGCOLLECTOR=perconalab/fluentbit:main-logcollector
 
 IMAGE_PMM_CLIENT=perconalab/pmm-client:3-dev-latest
 IMAGE_PMM_SERVER=perconalab/pmm-server:3-dev-latest

--- a/e2e-tests/release_versions
+++ b/e2e-tests/release_versions
@@ -26,7 +26,7 @@ IMAGE_POSTGIS18=perconalab/percona-postgresql-operator:main-ppg18-postgres-gis
 IMAGE_BACKREST18=perconalab/percona-postgresql-operator:main-pgbackrest18
 
 IMAGE_UPGRADE=perconalab/percona-postgresql-operator:main-upgrade
-IMAGE_LOGCOLLECTOR=tratata/fluentbit:main-logcollector
+IMAGE_LOGCOLLECTOR=perconalab/fluentbit:main-logcollector
 
 IMAGE_PMM_CLIENT=perconalab/pmm-client:3-dev-latest
 IMAGE_PMM_SERVER=perconalab/pmm-server:3-dev-latest


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
K8SPG-851 adds logcollector but it is not present in Makefile and release versions

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
