### PR TITLE
K8SPG-911: Fix enabling WAL encryption on a running cluster

### DIFF
--- a/internal/controller/postgrescluster/postgres.go
+++ b/internal/controller/postgrescluster/postgres.go
@@ -566,17 +566,23 @@ func (r *Reconciler) reconcilePGTDEProviders(
 		}
 	}
 
-	pod, _ := instances.writablePod(container)
-	if pod == nil {
-		log.V(1).Info("Waiting for a writable instance")
+	pods, allRunning := instances.runningPods(container)
+	if !allRunning {
+		log.V(1).Info("Waiting for all pods to be running")
 		return nil
 	}
 
-	pods, allRunning := instances.runningPods(container)
+	for _, p := range pods {
+		// We need to configure pg_tde after volumes are mounted and extension is created
+		if _, ok := p.Annotations[naming.TDEInstalledAnnotation]; !ok {
+			log.V(1).Info("Waiting for pg_tde to be installed", "pod", p.Name)
+			return nil
+		}
+	}
 
-	// We need to configure pg_tde after volumes are mounted and extension is created
-	if _, ok := pod.Annotations[naming.TDEInstalledAnnotation]; !ok {
-		log.V(1).Info("Waiting for pg_tde to be installed", "pod", pod.Name)
+	pod, _ := instances.writablePod(container)
+	if pod == nil {
+		log.V(1).Info("Waiting for a writable instance")
 		return nil
 	}
 

--- a/internal/controller/postgrescluster/postgres.go
+++ b/internal/controller/postgrescluster/postgres.go
@@ -569,7 +569,14 @@ func (r *Reconciler) reconcilePGTDEProviders(
 	pods, allRunning := instances.runningPods(container)
 	if !allRunning {
 		log.V(1).Info("Waiting for all pods to be running")
-		return nil
+		meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
+			Type:               v1beta1.PGTDEVaultProviderReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             "WaitingForInstances",
+			Message:            "waiting for all instances to be running to stage vault credentials",
+			ObservedGeneration: cluster.GetGeneration(),
+		})
+		return patchStatus()
 	}
 
 	for _, p := range pods {
@@ -658,18 +665,6 @@ func (r *Reconciler) reconcilePGTDEProviders(
 			// naming those paths. Staging on only some of them would leave the
 			// rest unable to resolve the key, and a replica promoted before
 			// phase 2 would come up without the credentials it needs.
-			if !allRunning {
-				log.Info("waiting for all instances to be running before staging vault credentials")
-				meta.SetStatusCondition(&cluster.Status.Conditions, metav1.Condition{
-					Type:               v1beta1.PGTDEVaultProviderReady,
-					Status:             metav1.ConditionFalse,
-					Reason:             "WaitingForInstances",
-					Message:            "waiting for all instances to be running to stage vault credentials",
-					ObservedGeneration: cluster.GetGeneration(),
-				})
-				return patchStatus()
-			}
-
 			log.Info("changing vault provider using temporary credentials", "instances", len(pods))
 			if err = r.stagePGTDEVaultCredentials(ctx, cluster.Namespace,
 				vault, pods, container, change.TempTokenPath, change.TempCAPath); err != nil {


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
If pg_tde and WAL encryption is enabled at the same time on a running cluster, some replicas fail to rejoin the cluster.

**Cause:**
Operator waits for primary to be rolled out with pg_tde installed before configuring providers and enabling WAL encryption but doesn't wait for replicas. Replicas might be in mid-rollout during these operations.

**Solution:**
Wait for all pods to be restarted with pg_tde mounts and extension is installed.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
