### PR TITLE
K8SPG-911: Reduce flakiness of pg-tde-wal-encrypt

### DIFF
--- a/e2e-tests/tests/pg-tde-wal-encrypt/09-read-data.yaml
+++ b/e2e-tests/tests/pg-tde-wal-encrypt/09-read-data.yaml
@@ -1,22 +1,35 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - timeout: 60
+  - timeout: 300
     script: |-
       set -o errexit
       set -o xtrace
 
       source ../../functions
 
-      primary=$(get_pod_by_role pg-tde-wal-encrypt primary name)
-      echo "Primary pod: ${primary}"
-      data=$(kubectl exec ${primary} -n "${NAMESPACE}" -- bash -c 'psql -q -t -d myapp -c "SELECT * from myTable;"')
+      # enabling WAL encryption restarts the postgres process, so both the primary
+      # election and the query itself can fail while the instances come back up
+      read_from_primary() {
+        local primary
+        primary=$(get_pod_by_role pg-tde-wal-encrypt primary name)
+        echo "Primary pod: ${primary}"
+        [[ -n ${primary} ]] || return 1
+        data=$(kubectl exec ${primary} -n "${NAMESPACE}" -- bash -c 'psql -q -t -d myapp -c "SELECT * from myTable;"')
+      }
+
+      read_from_pod() {
+        local pod=$1
+        data=$(kubectl exec ${pod} -n "${NAMESPACE}" -- bash -c 'psql -q -t -d myapp -c "SELECT * from myTable;"')
+      }
+
+      retry 12 5 read_from_primary
       kubectl create configmap -n "${NAMESPACE}" 09-read-from-primary --from-literal=data="${data}"
 
       t=1
       for i in $(kubectl get pods -n "${NAMESPACE}" -l postgres-operator.crunchydata.com/cluster=pg-tde-wal-encrypt,postgres-operator.crunchydata.com/role=replica -o jsonpath='{.items[*].metadata.name}'); do
         echo "Replica pod: ${i}"
-        data=$(kubectl exec ${i} -n "${NAMESPACE}" -- bash -c 'psql -q -t -d myapp -c "SELECT * from myTable;"')
+        retry 12 5 read_from_pod "${i}"
         kubectl create configmap -n "${NAMESPACE}" 09-read-from-replica-${t} --from-literal=data="${data}"
         t=$((t+1))
       done

--- a/e2e-tests/tests/pg-tde-wal-encrypt/14-read-data.yaml
+++ b/e2e-tests/tests/pg-tde-wal-encrypt/14-read-data.yaml
@@ -1,31 +1,47 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - timeout: 60
+  - timeout: 300
     script: |-
       set -o errexit
       set -o xtrace
 
       source ../../functions
 
-      primary=$(get_pod_by_role pg-tde-wal-encrypt primary name)
-      echo "Primary pod: ${primary}"
-      data=$(kubectl exec ${primary} -n "${NAMESPACE}" -- bash -c 'psql -q -t -d myapp -c "SELECT * from myTable;"')
+      # enabling WAL encryption restarts the postgres process, so both the primary
+      # election and the query itself can fail while the instances come back up
+      read_from_primary() {
+        local primary
+        primary=$(get_pod_by_role pg-tde-wal-encrypt primary name)
+        echo "Primary pod: ${primary}"
+        [[ -n ${primary} ]] || return 1
+        data=$(kubectl exec ${primary} -n "${NAMESPACE}" -- bash -c 'psql -q -t -d myapp -c "SELECT * from myTable;"')
+      }
+
+      read_from_pod() {
+        local pod=$1
+        data=$(kubectl exec ${pod} -n "${NAMESPACE}" -- bash -c 'psql -q -t -d myapp -c "SELECT * from myTable;"')
+      }
+
+      retry 12 5 read_from_primary
       kubectl create configmap -n "${NAMESPACE}" 14-read-from-primary --from-literal=data="${data}"
 
       t=1
       for i in $(kubectl get pods -n "${NAMESPACE}" -l postgres-operator.crunchydata.com/cluster=pg-tde-wal-encrypt,postgres-operator.crunchydata.com/role=replica -o jsonpath='{.items[*].metadata.name}'); do
         echo "Replica pod: ${i}"
-        data=$(kubectl exec ${i} -n "${NAMESPACE}" -- bash -c 'psql -q -t -d myapp -c "SELECT * from myTable;"')
+        retry 12 5 read_from_pod "${i}"
         kubectl create configmap -n "${NAMESPACE}" 14-read-from-replica-${t} --from-literal=data="${data}"
         t=$((t+1))
       done
 
       # the backup was taken with the rotated vault credentials, so the restored
       # cluster must still be able to reach the principal key
-      run_psql_command \
-        "SELECT pg_tde_verify_key();" \
-        "$(get_psql_uri pg-tde-wal-encrypt postgres)/myapp"
+      verify_key() {
+        run_psql_command \
+          "SELECT pg_tde_verify_key();" \
+          "$(get_psql_uri pg-tde-wal-encrypt postgres)/myapp"
+      }
+      retry 12 5 verify_key
 
       # K8SPG-911: the restore Job renames the data directory on its way out and Patroni
       # moves it back, so check the keyring link still resolves afterwards.


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
Postgres is restarted by Patroni after enabling WAL encryption. It usually coincides with read-data steps so we need to retry there.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
