### PR TITLE
K8SPG-1147: Allow disabling QAN with querySource "none"

### DIFF
--- a/build/crd/percona/generated/pgv2.percona.com_perconapgclusters.yaml
+++ b/build/crd/percona/generated/pgv2.percona.com_perconapgclusters.yaml
@@ -13165,6 +13165,7 @@ spec:
                     enum:
                     - pgstatmonitor
                     - pgstatstatements
+                    - none
                     type: string
                   resources:
                     properties:

--- a/config/crd/bases/pgv2.percona.com_perconapgclusters.yaml
+++ b/config/crd/bases/pgv2.percona.com_perconapgclusters.yaml
@@ -13579,6 +13579,7 @@ spec:
                     enum:
                     - pgstatmonitor
                     - pgstatstatements
+                    - none
                     type: string
                   resources:
                     properties:

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -13780,6 +13780,7 @@ spec:
                     enum:
                     - pgstatmonitor
                     - pgstatstatements
+                    - none
                     type: string
                   resources:
                     properties:

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -769,6 +769,7 @@ spec:
 #        cpu: 300m
 #    customClusterName: "<string>"
 #    postgresParams: "<string>"
+#    # Query Analytics source: pgstatstatements (default), pgstatmonitor, or none to disable QAN.
 #    querySource: pgstatmonitor
   logcollector:
     enabled: true

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -13780,6 +13780,7 @@ spec:
                     enum:
                     - pgstatmonitor
                     - pgstatstatements
+                    - none
                     type: string
                   resources:
                     properties:

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -13780,6 +13780,7 @@ spec:
                     enum:
                     - pgstatmonitor
                     - pgstatstatements
+                    - none
                     type: string
                   resources:
                     properties:

--- a/e2e-tests/tests/monitoring/10-disable-qan-query-source.yaml
+++ b/e2e-tests/tests/monitoring/10-disable-qan-query-source.yaml
@@ -1,0 +1,35 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |-
+      set -o errexit
+      set -o xtrace
+
+      source ../../functions
+
+      # K8SPG-1147: querySource "none" must turn Query Analytics off while
+      # leaving metrics collection in place.
+      kubectl -n ${NAMESPACE} patch perconapgcluster/monitoring --type=merge -p '{
+        "spec":{
+          "pmm":{"querySource":"none"}
+        }
+      }'
+
+      # Wait for PMM to re-register the service without a QAN agent.
+      sleep 80
+
+      primary=$(get_pod_by_role monitoring primary name)
+      kubectl -n ${NAMESPACE} exec ${primary} -c pmm-client -- pmm-admin list
+
+      # No QAN agent of either flavor may be registered.
+      if kubectl -n ${NAMESPACE} exec ${primary} -c pmm-client -- pmm-admin list | grep -E 'postgresql_pgstatements_agent|postgresql_pgstatmonitor_agent'; then
+        echo "a QAN agent is still running with querySource=none"
+        exit 1
+      fi
+
+      # Metrics collection must be unaffected.
+      if ! kubectl -n ${NAMESPACE} exec ${primary} -c pmm-client -- pmm-admin list | grep postgres_exporter; then
+        echo "postgres_exporter is not running"
+        exit 1
+      fi
+    timeout: 360

--- a/percona/pmm/pmm_test.go
+++ b/percona/pmm/pmm_test.go
@@ -226,3 +226,69 @@ func TestSidecarContainer(t *testing.T) {
 	assert.Equal(t, "/pgconf/tls", container.VolumeMounts[0].MountPath)
 	assert.True(t, container.VolumeMounts[0].ReadOnly)
 }
+
+func TestQuerySource(t *testing.T) {
+	t.Parallel()
+
+	for name, tt := range map[string]struct {
+		crVersion string
+		source    v2.PMMQuerySource
+		expected  string
+	}{
+		"pg_stat_statements is mapped to the pmm-admin spelling": {
+			crVersion: "2.9.0",
+			source:    v2.PgStatStatements,
+			expected:  "pgstatements",
+		},
+		"pg_stat_monitor is passed through": {
+			crVersion: "2.9.0",
+			source:    v2.PgStatMonitor,
+			expected:  "pgstatmonitor",
+		},
+		"none is passed through to disable QAN": {
+			crVersion: "2.9.0",
+			source:    v2.QuerySourceNone,
+			expected:  "none",
+		},
+		"none is passed through on older CR versions too": {
+			crVersion: "2.8.0",
+			source:    v2.QuerySourceNone,
+			expected:  "none",
+		},
+		"pg_stat_statements is not remapped before 2.9.0": {
+			crVersion: "2.8.0",
+			source:    v2.PgStatStatements,
+			expected:  "pgstatstatements",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			pgc := &v2.PerconaPGCluster{
+				Spec: v2.PerconaPGClusterSpec{CRVersion: tt.crVersion},
+			}
+
+			assert.Equal(t, tt.expected, querySource(pgc, tt.source))
+		})
+	}
+}
+
+// TestAgentPrerunScriptQuerySourceNone guards the K8SPG-1147 contract: a cluster
+// with querySource "none" must register the service with --query-source=none so
+// pmm-admin skips the QAN agent instead of silently ignoring an unknown value.
+func TestAgentPrerunScriptQuerySourceNone(t *testing.T) {
+	t.Parallel()
+
+	pgc := &v2.PerconaPGCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+		Spec: v2.PerconaPGClusterSpec{
+			CRVersion: "2.9.0",
+			PMM:       &v2.PMMSpec{Enabled: true, QuerySource: v2.QuerySourceNone},
+		},
+	}
+
+	script := agentPrerunScript(pgc)
+
+	assert.Contains(t, script, "--query-source=none")
+	assert.NotContains(t, script, "--query-source=pgstat")
+}

--- a/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
+++ b/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
@@ -1195,6 +1195,9 @@ type PMMQuerySource string
 const (
 	PgStatStatements PMMQuerySource = "pgstatstatements"
 	PgStatMonitor    PMMQuerySource = "pgstatmonitor"
+	// QuerySourceNone disables Query Analytics for the cluster. Metrics are
+	// still collected; only the QAN agent is left unregistered.
+	QuerySourceNone PMMQuerySource = "none"
 )
 
 type PMMSpec struct {
@@ -1223,7 +1226,9 @@ type PMMSpec struct {
 	// +kubebuilder:validation:Required
 	Secret string `json:"secret,omitempty"`
 
-	// +kubebuilder:validation:Enum={pgstatmonitor,pgstatstatements}
+	// QuerySource selects the Query Analytics source for the cluster.
+	// Use "none" to disable Query Analytics while keeping metrics collection.
+	// +kubebuilder:validation:Enum={pgstatmonitor,pgstatstatements,none}
 	// +kubebuilder:default=pgstatstatements
 	// +kubebuilder:validation:Required
 	QuerySource PMMQuerySource `json:"querySource,omitempty"`

--- a/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types_test.go
+++ b/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types_test.go
@@ -464,6 +464,43 @@ func TestPerconaPGCluster_ToCrunchy(t *testing.T) {
 				assert.False(t, actual.Spec.Extensions.PGStatStatements)
 			},
 		},
+		"handles PMM none query source": {
+			expectedPerconaPGCluster: &PerconaPGCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Spec: PerconaPGClusterSpec{
+					CRVersion:       "2.9.0",
+					PostgresVersion: 15,
+					PMM: &PMMSpec{
+						Enabled:     true,
+						QuerySource: QuerySourceNone,
+					},
+					InstanceSets: PGInstanceSets{
+						{
+							Name:     "instance1",
+							Replicas: &[]int32{1}[0],
+							DataVolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+							},
+						},
+					},
+					Backups: Backups{
+						PGBackRest: PGBackRestArchive{
+							Repos: []crunchyv1beta1.PGBackRestRepo{
+								{Name: "repo1"},
+							},
+						},
+					},
+				},
+			},
+			assertClusterFunc: func(t *testing.T, actual *crunchyv1beta1.PostgresCluster, _ *PerconaPGCluster) {
+				// Neither query-source extension is installed when QAN is off.
+				assert.False(t, actual.Spec.Extensions.PGStatMonitor)
+				assert.False(t, actual.Spec.Extensions.PGStatStatements)
+			},
+		},
 		"handles AutoCreateUserSchema annotation": {
 			expectedPerconaPGCluster: &PerconaPGCluster{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**

There is no supported way to turn Query Analytics off for a cluster:

```
spec.pmm.querySource: Unsupported value: "none":
  supported values: "pgstatmonitor", "pgstatstatements"
```

This matters for PMM HA, where PMM's own PostgreSQL is an internal component whose queries should not appear in QAN. Since 2.9.0 the default is `pgstatstatements` and it resolves correctly, so QAN is on by default there with no way to disable it.

**Cause:**

Only the CRD enum rejects `none`. `pmm-admin` has accepted it since 2021: the flag carries no enum tag, `none` is an explicit case in its query-source switch that leaves both QAN agent flags false, and `managed` creates `postgres_exporter` unconditionally while gating each QAN agent separately. The service registers, metrics keep flowing, and no QAN agent is created. `percona/pmm/pmm.go:286` already documents that PMM accepts `none`.

**Solution:**

Add `none` to the `querySource` enum and regenerate the CRDs.

No version gate: widening an enum is backward compatible, and `none` needs no remapping in `querySource()`. Extension defaulting already handles it, since both `pg_stat_statements` and `pg_stat_monitor` compare false against it.

Verified: `make generate VERSION=main` produces no drift, full `go test ./...` passes.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly? — [K8SPG-1147](https://perconadev.atlassian.net/browse/K8SPG-1147)
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)? — not set yet; `querySource` is documented, so this needs a doc update for the new value
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)? — not set yet

**Tests**
- [x] Is an E2E test/test case added for the new feature/change? — `e2e-tests/tests/monitoring/10-disable-qan-query-source.yaml` asserts no QAN agent and `postgres_exporter` still present
- [x] Are unit tests added where appropriate? — `TestQuerySource`, `TestAgentPrerunScriptQuerySourceNone`, and a `ToCrunchy` case asserting neither extension is installed

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files? — `deploy/cr.yaml`
- [x] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)? — no change needed; `pg-db` already passes `querySource` through, so `pmm.querySource: none` works once the enum accepts it
- [ ] Did we add proper logging messages for operator actions? — n/a
- [x] Did we ensure compatibility with the previous version or cluster upgrade process? — additive enum value, existing values unchanged
- [x] Does the change support oldest and newest supported PG version? — not PG-version dependent
- [x] Does the change support oldest and newest supported Kubernetes version? — not K8s-version dependent


[K8SPG-1147]: https://perconadev.atlassian.net/browse/K8SPG-1147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ