### PR TITLE
K8SPG-786 use pg_stat_statements in upgrade test and additional test fixes

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -2328,8 +2328,9 @@ function get_available_k8s_versions() {
 			versions=$(
 				gcloud container get-server-config \
 					--region "${region}" \
-					--format="value(validMasterVersions)" 2>/dev/null \
-					| tr ';' '\n' \
+					--flatten='channels[].validVersions[]' \
+					--filter='channels.channel=STABLE' \
+					--format='value(channels.validVersions)' 2>/dev/null \
 					| awk -F'.' '!seen[$1"."$2]++'
 			)
 			;;

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -2637,7 +2637,13 @@ check_logs_for_errors() {
 	# the operator logs JSON only with LOG_STRUCTURED=true, deploy/operator.yaml
 	# sets it to false, so match the console encoder format as well
 	kubectl -n "$op_ns" logs deployment/percona-postgresql-operator --since-time="$since" 2>/dev/null \
-		| grep -E '"level":"error"|[[:space:]]ERROR[[:space:]]|panic:' | grep -Evf "$allow" >"${TEMP_DIR}/log_errors_operator.txt" || true
+		| grep -E '"level":"error"|[[:space:]]ERROR[[:space:]]|panic:' \
+		| awk -v namespace="$NAMESPACE" '
+			!match($0, /"namespace"[[:space:]]*:[[:space:]]*"[^"]+"/) ||
+			index($0, "\"namespace\":\"" namespace "\"") ||
+			index($0, "\"namespace\": \"" namespace "\"")
+		' \
+		| grep -Evf "$allow" >"${TEMP_DIR}/log_errors_operator.txt" || true
 	for pod in $(kubectl -n "$NAMESPACE" get pods -l postgres-operator.crunchydata.com/cluster="$cluster",postgres-operator.crunchydata.com/data=postgres -o name); do
 		kubectl -n "$NAMESPACE" logs "$pod" -c database --since-time="$since" 2>/dev/null \
 			| grep -E 'FATAL|PANIC' | grep -Evf "$allow" >>"${TEMP_DIR}/log_errors_postgres.txt" || true

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -132,7 +132,7 @@ function remove_all_finalizers() {
 			if [[ $(kubectl -n "${NAMESPACE}" get "$resource" "$name" -o yaml | yq '.metadata.finalizers | length') == "0" ]]; then
 				continue
 			fi
-			kubectl -n "${NAMESPACE}" patch "$resource" "$name" --type=json -p='[{"op": "remove", "path": "/metadata/finalizers"}]'
+			kubectl -n "${NAMESPACE}" patch "$resource" "$name" --type=json -p='[{"op":"replace","path":"/metadata/finalizers","value":[]}]'
 			kubectl -n "${NAMESPACE}" delete "$resource" "$name" --wait=0
 		done
 	done

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -132,7 +132,7 @@ function remove_all_finalizers() {
 			if [[ $(kubectl -n "${NAMESPACE}" get "$resource" "$name" -o yaml | yq '.metadata.finalizers | length') == "0" ]]; then
 				continue
 			fi
-			kubectl -n "${NAMESPACE}" patch "$resource" "$name" --type=json -p='[{"op":"replace","path":"/metadata/finalizers","value":[]}]'
+			kubectl -n "${NAMESPACE}" patch "$resource" "$name" --type=merge -p='{"metadata":{"finalizers":[]}}'
 			kubectl -n "${NAMESPACE}" delete "$resource" "$name" --wait=0
 		done
 	done

--- a/e2e-tests/tests/builtin-extensions/00-deploy-operator.yaml
+++ b/e2e-tests/tests/builtin-extensions/00-deploy-operator.yaml
@@ -1,7 +1,8 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - script: |-
+  - timeout: 200
+    script: |-
       set -o errexit
       set -o xtrace
 
@@ -12,4 +13,3 @@ commands:
       deploy_client
       deploy_s3_secrets
       deploy_minio
-    timeout: 120

--- a/e2e-tests/tests/migration-from-crunchy-backup-restore/99-cleanup.yaml
+++ b/e2e-tests/tests/migration-from-crunchy-backup-restore/99-cleanup.yaml
@@ -20,7 +20,7 @@ commands:
 
       kubectl delete postgrescluster crunchy-source -n "${CRUNCHY_NS}" --ignore-not-found || true
       kubectl patch postgrescluster crunchy-source -n "${CRUNCHY_NS}" \
-        --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null || true
+        --type=json -p='[{"op":"replace","path":"/metadata/finalizers","value":[]}]' 2>/dev/null || true
 
       helm uninstall pgo --namespace "${CRUNCHY_NS}" --ignore-not-found || true
 

--- a/e2e-tests/tests/migration-from-crunchy-pv/03-migrate-pv.yaml
+++ b/e2e-tests/tests/migration-from-crunchy-pv/03-migrate-pv.yaml
@@ -50,7 +50,7 @@ commands:
       # 3. Delete the Crunchy cluster and operator — no longer needed once the PV
       #    is retained.  Strip finalizers first so the CR is removed cleanly.
       kubectl patch postgrescluster crunchy-source -n "${NAMESPACE}" \
-        --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null || true
+        --type=json -p='[{"op":"replace","path":"/metadata/finalizers","value":[]}]' 2>/dev/null || true
 
       kubectl delete postgrescluster crunchy-source -n "${NAMESPACE}" --ignore-not-found
 

--- a/e2e-tests/tests/migration-from-crunchy-pv/99-cleanup.yaml
+++ b/e2e-tests/tests/migration-from-crunchy-pv/99-cleanup.yaml
@@ -19,7 +19,7 @@ commands:
       # Remove Crunchy source cluster if it still exists (e.g. test failed
       # before step 03 could delete it).
       kubectl patch postgrescluster crunchy-source -n "${NAMESPACE}" \
-        --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null || true
+        --type=json -p='[{"op":"replace","path":"/metadata/finalizers","value":[]}]' 2>/dev/null || true
       kubectl delete postgrescluster crunchy-source -n "${NAMESPACE}" \
         --ignore-not-found || true
 

--- a/e2e-tests/tests/migration-from-crunchy-standby/99-cleanup.yaml
+++ b/e2e-tests/tests/migration-from-crunchy-standby/99-cleanup.yaml
@@ -22,7 +22,7 @@ commands:
       # Strip finalizers so deletion is not blocked by a missing operator
       kubectl delete postgrescluster crunchy-source -n "${CRUNCHY_NS}" --ignore-not-found || true
       kubectl patch postgrescluster crunchy-source -n "${CRUNCHY_NS}" \
-        --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]' 2>/dev/null || true
+        --type=json -p='[{"op":"replace","path":"/metadata/finalizers","value":[]}]' 2>/dev/null || true
 
       helm uninstall pgo --namespace "${CRUNCHY_NS}" --ignore-not-found || true
       kubectl delete namespace "${CRUNCHY_NS}" --ignore-not-found || true

--- a/e2e-tests/tests/operator-upgrade-extensions/01-create-cluster.yaml
+++ b/e2e-tests/tests/operator-upgrade-extensions/01-create-cluster.yaml
@@ -42,7 +42,7 @@ commands:
 
       # released-CRD canary: unknown fields are silently pruned — fail loudly instead
       applied_builtin=$(kubectl -n "${NAMESPACE}" get perconapgcluster ${test_name} -o jsonpath='{.spec.extensions.builtin}')
-      for ext in pg_stat_monitor pg_audit pgvector pg_repack; do
+      for ext in pg_stat_statements pg_audit pgvector pg_repack; do
           if ! echo "$applied_builtin" | grep -q "\"$ext\":true"; then
               echo "ERROR: builtin extension '$ext' was pruned by the released CRD: $applied_builtin"
               exit 1

--- a/e2e-tests/tests/operator-upgrade-extensions/03-enable-extensions-and-write-data.yaml
+++ b/e2e-tests/tests/operator-upgrade-extensions/03-enable-extensions-and-write-data.yaml
@@ -10,7 +10,7 @@ commands:
 
       uri="postgres:$(get_psql_user_pass ${test_name}-pguser-postgres)@$(get_psql_user_host ${test_name}-pguser-postgres)"
 
-      for ext in pg_stat_monitor pgaudit vector pg_repack pg_cron; do
+      for ext in pg_stat_statements pgaudit vector pg_repack pg_cron; do
           run_psql_local "\c postgres \\\\\\ CREATE EXTENSION IF NOT EXISTS \"$ext\"" "$uri"
       done
 

--- a/e2e-tests/tests/operator-upgrade-extensions/conf/operator-upgrade-extensions.yaml
+++ b/e2e-tests/tests/operator-upgrade-extensions/conf/operator-upgrade-extensions.yaml
@@ -23,7 +23,7 @@ spec:
       secret:
         name: minio-secret
     builtin:
-      pg_stat_monitor: true
+      pg_stat_statements: true
       pg_audit: true
       pgvector: true
       pg_repack: true


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Description:**

Use pg_stat_statements instead of pg_stat_monitor in the operator-upgrade-extensions test

Additionally:

- Fetch GKE versions exclusively from the STABLE release channel and keep one patch version per Kubernetes minor version.
- Filter cluster-wide operator error logs by the current KUTTL namespace.
  - Logs from other test namespaces are ignored.
  - Global errors without a namespace are still validated.
- Increase the builtin-extensions deployment timeout from 120 to 200 seconds to include MinIO startup.
- Replace finalizers instead of removing, in order to prevent conflicts with finalizers logic itself.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
