### PR TITLE
K8SPG-1099 clear inner PostgresCluster standby when spec.standby removed

### DIFF
--- a/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
+++ b/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go
@@ -673,6 +673,7 @@ func (cr *PerconaPGCluster) ToCrunchy(ctx context.Context, postgresCluster *crun
 	postgresCluster.Spec.Paused = cr.Spec.Unmanaged
 	postgresCluster.Spec.Shutdown = cr.Spec.Pause
 
+	postgresCluster.Spec.Standby = nil
 	if cr.Spec.Standby != nil {
 		postgresCluster.Spec.Standby = cr.Spec.Standby.PostgresStandbySpec
 	}

--- a/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types_test.go
+++ b/pkg/apis/pgv2.percona.com/v2/perconapgcluster_types_test.go
@@ -771,6 +771,47 @@ func TestPerconaPGCluster_ToCrunchy(t *testing.T) {
 				assert.False(t, actual.Spec.Extensions.SetUser)
 			},
 		},
+		"clears standby on existing PostgresCluster when standby is removed": {
+			expectedPerconaPGCluster: &PerconaPGCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Spec: PerconaPGClusterSpec{
+					CRVersion:       version.Version(),
+					PostgresVersion: 18,
+					InstanceSets: PGInstanceSets{
+						{
+							Name:     "instance1",
+							Replicas: &[]int32{1}[0],
+							DataVolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+							},
+						},
+					},
+					Backups: Backups{
+						PGBackRest: PGBackRestArchive{
+							Repos: []crunchyv1beta1.PGBackRestRepo{},
+						},
+					},
+				},
+			},
+			inputPostgresCluster: &crunchyv1beta1.PostgresCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Spec: crunchyv1beta1.PostgresClusterSpec{
+					Standby: &crunchyv1beta1.PostgresStandbySpec{
+						Enabled:  true,
+						RepoName: "repo1",
+					},
+				},
+			},
+			assertClusterFunc: func(t *testing.T, actual *crunchyv1beta1.PostgresCluster, _ *PerconaPGCluster) {
+				assert.Nil(t, actual.Spec.Standby)
+			},
+		},
 	}
 
 	for testName, tt := range tests {


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
## Problem

**Problem:**
When `spec.standby` is removed from a `PerconaPGCluster`, the inner `PostgresCluster` keeps its previous `spec.standby` (`enabled: true`). The cluster therefore stays in standby mode and never promotes, even though the user's CR no longer asks for standby. The only workaround today is to explicitly set `spec.standby.enabled: false` instead of deleting the block.

## Root cause

**Cause:**
`PerconaPGCluster.ToCrunchy()` (`pkg/apis/pgv2.percona.com/v2/perconapgcluster_types.go:676-678`) only assigns `postgresCluster.Spec.Standby` when `cr.Spec.Standby != nil`:

```go
if cr.Spec.Standby != nil {
    postgresCluster.Spec.Standby = cr.Spec.Standby.PostgresStandbySpec
}
```

`ToCrunchy` is called from the `controllerutil.CreateOrUpdate` mutate function in `percona/controller/pgcluster/controller.go:500-505`, so it operates on the live `PostgresCluster` object fetched from the API server. With no `else` branch, a `Standby` that was set on a previous reconcile is never cleared. Other fields in the same function (`Paused`, `Shutdown`, `DataSource`, `Patroni`, ...) are assigned unconditionally and do not have this problem.

## Fix

**Solution:**
Reset `postgresCluster.Spec.Standby` to `nil` before the conditional assignment, so the inner `PostgresCluster` always mirrors the `PerconaPGCluster`: standby is set when the user sets it and cleared when the user removes it. One-line change, no API or CRD changes.

## How tested

Added a case to the existing table-driven `TestPerconaPGCluster_ToCrunchy`: the input `PostgresCluster` has `Spec.Standby` set (`Enabled: true, RepoName: "repo1"`), the `PerconaPGCluster` has no `spec.standby`, and the test asserts the resulting `Spec.Standby` is `nil`.

Before the fix (`go test ./pkg/apis/pgv2.percona.com/v2/ -run 'TestPerconaPGCluster_ToCrunchy$'`):

```
--- FAIL: TestPerconaPGCluster_ToCrunchy (0.00s)
    --- FAIL: TestPerconaPGCluster_ToCrunchy/clears_standby_on_existing_PostgresCluster_when_standby_is_removed (0.00s)
        perconapgcluster_types_test.go:812:
            	Error:      	Expected nil, but got: &v1beta1.PostgresStandbySpec{Enabled:true, RepoName:"repo1", Host:"", Port:(*int32)(nil)}
FAIL
FAIL	github.com/percona/percona-postgresql-operator/v3/pkg/apis/pgv2.percona.com/v2	0.025s
```

After the fix:

```
--- PASS: TestPerconaPGCluster_ToCrunchy (0.00s)
ok  	github.com/percona/percona-postgresql-operator/v3/pkg/apis/pgv2.percona.com/v2	0.017s
```

The whole `./pkg/apis/pgv2.percona.com/v2/` package passes, and `gofmt`, `go vet` and `go build` of the changed packages are clean.

## Links

- Fixes https://github.com/percona/percona-postgresql-operator/issues/1687
- Jira: K8SPG-1099

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly? (K8SPG-1099, created by the maintainers from the issue above)
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files? (no option changes)
- [x] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)? (no option changes)
- [x] Did we add proper logging messages for operator actions? (no new actions)
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported PG version?
- [x] Does the change support oldest and newest supported Kubernetes version?

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
