### PR TITLE
Release 3.1.0 generate bundle

### DIFF
--- a/installers/olm/Makefile
+++ b/installers/olm/Makefile
@@ -169,8 +169,8 @@ tools/$(SYSTEM)/venv:
 
 tools: tools/$(SYSTEM)/yq
 tools/$(SYSTEM)/yq: | tools/$(SYSTEM)/venv
-       'tools/$(SYSTEM)/venv/bin/python' -m pip install yq
-       cd '$(dir $@)' && ln -s venv/bin/yq
+	'tools/$(SYSTEM)/venv/bin/python' -m pip install yq
+	cd '$(dir $@)' && ln -s venv/bin/yq
 
 # ==============================================================================
 # Development Targets

--- a/installers/olm/Makefile
+++ b/installers/olm/Makefile
@@ -19,7 +19,9 @@ IMAGE_TAG_BASE ?= $(IMAGE_TAG_OWNER)/$(NAME)
 CONTAINER ?= docker
 
 # Bundle configuration
-OPENSHIFT_VERSIONS ?= v4.18-v4.21
+# OPENSHIFT_VERSIONS: optional. If unset, generate.sh derives v<min>-v<max>
+# from OPENSHIFT_MIN/MAX in e2e-tests/release_versions (or @@RHEL_VERSIONS@@
+# if that file is unavailable).
 DOCKER_DEFAULT_PLATFORM ?= linux/amd64
 
 # Image configuration
@@ -167,8 +169,8 @@ tools/$(SYSTEM)/venv:
 
 tools: tools/$(SYSTEM)/yq
 tools/$(SYSTEM)/yq: | tools/$(SYSTEM)/venv
-	'tools/$(SYSTEM)/venv/bin/python' -m pip install yq
-	cd '$(dir $@)' && ln -s venv/bin/yq
+       'tools/$(SYSTEM)/venv/bin/python' -m pip install yq
+       cd '$(dir $@)' && ln -s venv/bin/yq
 
 # ==============================================================================
 # Development Targets

--- a/installers/olm/README.md
+++ b/installers/olm/README.md
@@ -97,7 +97,10 @@ Common variables:
 
 ```text
 VERSION              Release version. Required.
-OPENSHIFT_VERSIONS   OpenShift range annotation. Default: v4.18-v4.21
+OPENSHIFT_VERSIONS   OpenShift range annotation. If unset, derived from
+                     OPENSHIFT_MIN/MAX in e2e-tests/release_versions
+                     (v<major.minor>-v<major.minor>). If that file is
+                     missing, @@RHEL_VERSIONS@@.
 IMAGE                Community operator image.
 REDHAT_OPERATOR_IMAGE Red Hat operator image.
 BUNDLE_DISTRO        Bundle to build: community or redhat.

--- a/installers/olm/bundle.annotations.yaml
+++ b/installers/olm/bundle.annotations.yaml
@@ -26,7 +26,8 @@ annotations:
   operators.operatorframework.io.bundle.channels.v1: v5
   operators.operatorframework.io.bundle.channel.default.v1: v5
 
-  # This default is overwritten by generate.sh from OPENSHIFT_VERSIONS.
+  # Overwritten by generate.sh: OPENSHIFT_VERSIONS, else OPENSHIFT_MIN/MAX
+  # from e2e-tests/release_versions, else @@RHEL_VERSIONS@@.
   # https://github.com/operator-framework/community-operators/blob/8a36a33/docs/packaging-required-criteria-ocp.md
   # https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory
   com.redhat.delivery.operator.bundle: true

--- a/installers/olm/distributions/redhat.sh
+++ b/installers/olm/distributions/redhat.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 redhat_release="${VERSION}"
 redhat_registry="registry.connect.redhat.com"
 redhat_catalog_api="${REDHAT_CATALOG_API:-https://catalog.redhat.com/api/containers/v1}"
-redhat_catalog_curl_timeout="${REDHAT_CATALOG_CURL_TIMEOUT:-20}"
+redhat_catalog_curl_timeout="${REDHAT_CATALOG_CURL_TIMEOUT:-90}"
 redhat_operator_repository="percona/percona-postgresql-operator"
 redhat_containers_repository="percona/percona-postgresql-operator-containers"
 redhat_operator_tag="${REDHAT_OPERATOR_TAG:-${redhat_release}}"
@@ -243,25 +243,86 @@ apply_csv_overrides() {
 	log "Red Hat CSV overrides applied"
 }
 
+# True if $1 is strictly less than $2 using version sort (2.9.0 < 3.1.0).
+version_lt() {
+	[[ $1 != "$2" ]] || return 1
+	[[ $(printf '%s\n%s\n' "$1" "$2" | sort -V) == "$1"$'\n'"$2" ]]
+}
+
+# Strip a leading "v" or "v." so v3.1.0, v.3.1.0, and 3.1.0 all become 3.1.0.
+normalize_git_tag() {
+	sed -E 's/^v\.?//' <<<"$1"
+}
+
+fetch_remote_tags() {
+	local remote="https://github.com/percona/percona-postgresql-operator"
+
+	log "Fetching tags from ${remote}"
+
+	git -C "${repo_root}" fetch --tags --force "${remote}" \
+		|| abort "Failed to fetch tags from ${remote}"
+}
+
+# Tags strictly after the last seed version and strictly before VERSION.
+# Seed entries such as 2.9.0-cw are kept as-is and never inferred from git.
+discovered_skip_versions() {
+	local last_seed="$1"
+	local current="$2"
+	local tag version
+
+	fetch_remote_tags
+
+	while IFS= read -r tag; do
+		[[ -n ${tag} ]] || continue
+
+		version="$(normalize_git_tag "${tag}")"
+		[[ ${version} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || continue
+
+		if version_lt "${last_seed}" "${version}" && version_lt "${version}" "${current}"; then
+			printf '%s\n' "${version}"
+		fi
+	done < <(git -C "${repo_root}" tag --list) \
+		| sort -u -V
+}
+
 prepare_redhat_csv_vars() {
 	local file_name="$1"
+	local last_seed extra_versions extra_json
+
+	local seed_versions=(
+		"2.5.0"
+		"2.6.0"
+		"2.6.1"
+		"2.7.0"
+		"2.8.0"
+		"2.8.1"
+		"2.8.2"
+		"2.9.0"
+		"2.9.0-cw"
+		"3.0.0"
+	)
+
+	last_seed="${seed_versions[-1]}"
+	extra_versions="$(discovered_skip_versions "${last_seed}" "${VERSION}")"
+
+	if [[ -n ${extra_versions} ]]; then
+		log "Adding Red Hat skips from git tags after ${last_seed} and before ${VERSION}: ${extra_versions//$'\n'/, }"
+		extra_json="$(printf '%s\n' "${extra_versions}" | jq -R . | jq -s -c .)"
+	else
+		log "No git tags found between ${last_seed} and ${VERSION}; using the seed skip list"
+		extra_json='[]'
+	fi
 
 	redhat_skips="$(
 		jq -nc \
 			--arg file_name "${file_name}" \
+			--argjson extra "${extra_json}" \
+			--args \
 			'
-        [
-          "2.5.0",
-          "2.6.0",
-          "2.6.1",
-          "2.7.0",
-          "2.8.0",
-          "2.8.1",
-          "2.8.2",
-          "2.9.0"
-        ]
+        $ARGS.positional + $extra
         | map("\($file_name).v\(.)")
-      '
+      ' \
+			-- "${seed_versions[@]}"
 	)"
 
 	printf '%s\n' "${redhat_skips}"

--- a/installers/olm/distributions/redhat.sh
+++ b/installers/olm/distributions/redhat.sh
@@ -11,6 +11,7 @@ redhat_operator_repository="percona/percona-postgresql-operator"
 redhat_containers_repository="percona/percona-postgresql-operator-containers"
 redhat_operator_tag="${REDHAT_OPERATOR_TAG:-${redhat_release}}"
 redhat_upgrade_tag="${REDHAT_UPGRADE_TAG:-${redhat_release}-upgrade}"
+redhat_logcollector_tag="${REDHAT_LOGCOLLECTOR_TAG:-${redhat_release}-logcollector}"
 redhat_related_images="[]"
 
 required_vars=(
@@ -133,9 +134,13 @@ build_redhat_related_images() {
 	# shellcheck source=/dev/null
 	source "${repo_root}/e2e-tests/release_versions"
 
+	# Official majors only (IMAGE_POSTGRESQL14). Flavor suffixes such as
+	# _UBI8 / _UBI10 / _UBI9_COMMUNITY are e2e matrix variants, not certified
+	# relatedImages.
 	pg_versions="$(
 		compgen -A variable IMAGE_POSTGRESQL \
 			| sed 's/^IMAGE_POSTGRESQL//' \
+			| grep -E '^[0-9]+$' \
 			| sort -rn
 	)"
 
@@ -162,6 +167,7 @@ build_redhat_related_images() {
 		"$(release_component_tag pgbouncer "$(image_version "${IMAGE_PGBOUNCER18}")")"
 
 	add_related_image "pmm" "${redhat_containers_repository}" "${redhat_release}-pmm3"
+	add_related_image "logcollector" "${redhat_containers_repository}" "${redhat_logcollector_tag}"
 	add_related_image "operator" "${redhat_operator_repository}" "${redhat_operator_tag}"
 	add_related_image "pgupgrade" "${redhat_containers_repository}" "${redhat_upgrade_tag}"
 
@@ -171,6 +177,7 @@ build_redhat_related_images() {
 		--arg pgbouncer_image "$(related_image_by_name pgbouncer)" \
 		--arg pgbackrest_image "$(related_image_by_name pgbackrest)" \
 		--arg pmm_image "$(related_image_by_name pmm)" \
+		--arg logcollector_image "$(related_image_by_name logcollector)" \
 		--arg upgrade_image "$(related_image_by_name pgupgrade)" \
 		--argjson related_images "${redhat_related_images}" \
 		'{
@@ -179,6 +186,7 @@ build_redhat_related_images() {
 			pgbouncerImage: $pgbouncer_image,
 			pgbackrestImage: $pgbackrest_image,
 			pmmImage: $pmm_image,
+			logcollectorImage: $logcollector_image,
 			upgradeImage: $upgrade_image,
 			relatedImages: $related_images
 		}'
@@ -192,14 +200,26 @@ apply_csv_overrides() {
 
 	log "Applying Red Hat certified CSV overrides"
 
+	# yq --yaml-roundtrip encodes preserved comments as "__yq_comment*" string
+	# entries inside sequences: guard .type lookups against them, then drop any
+	# that yq fails to turn back into comments (they would otherwise be emitted
+	# as literal list items and break the CSV schema). Sequences of real strings
+	# such as keywords, skips and RBAC verbs are left untouched.
 	yq --in-place --yaml-roundtrip \
 		'
       .metadata.annotations.certified = "true"
       | (
           .spec.installModes[]
-          | select(.type == "MultiNamespace")
+          | select((type == "object") and (.type == "MultiNamespace"))
           | .supported
         ) = true
+      | walk(
+          if type == "array" then
+            map(select((type != "string") or (startswith("__yq_comment") | not)))
+          else
+            .
+          end
+        )
     ' \
 		"${csv_file}"
 
@@ -277,6 +297,7 @@ rewrite_crd_examples_images() {
             | .spec.proxy.pgBouncer.image = $images.pgbouncerImage
             | .spec.backups.pgbackrest.image = $images.pgbackrestImage
             | .spec.pmm.image = $images.pmmImage
+            | .spec.logcollector.image = $images.logcollectorImage
 
           elif .kind == "PerconaPGUpgrade" then
             .spec.image = $images.upgradeImage

--- a/installers/olm/distributions/redhat.sh
+++ b/installers/olm/distributions/redhat.sh
@@ -214,8 +214,10 @@ apply_csv_overrides() {
           | .supported
         ) = true
       | walk(
-          if type == "array" then
-            map(select((type != "string") or (startswith("__yq_comment") | not)))
+          if type == "object" then
+            with_entries(select((.key | tostring | startswith("__yq_comment_")) | not))
+          elif type == "array" then
+            map(select((type == "string" and startswith("__yq_comment_")) | not))
           else
             .
           end

--- a/installers/olm/generate.sh
+++ b/installers/olm/generate.sh
@@ -81,7 +81,7 @@ select_manifests() {
 	local kind="$1"
 	shift
 
-	yq --slurp --yaml-roundtrip \
+	yq --slurp --yaml-output \
 		--arg kind "${kind}" \
 		'map(select(.kind == $kind))' \
 		"$@"
@@ -103,6 +103,9 @@ check_tools() {
 	require kubectl
 	require operator-sdk
 	require jq
+	# yq 4 --yaml-output strips comments but also literal block scalars
+	# (alm-examples). --yaml-roundtrip keeps both; comment keys are dropped
+	# in jq with strip_yq_comments.
 	require bash -c "yq --help | grep -q -- '--yaml-roundtrip'"
 
 	log "All tools available"
@@ -183,6 +186,30 @@ render_operator_manifests() {
 	log "Extracted manifests: CRDs, Deployments, ServiceAccounts, Roles, ClusterRoles"
 }
 
+# operator-sdk init still runs `go mod tidy` after scaffolding, even with
+# --fetch-deps=false. Bundle generation deletes go.mod immediately and never
+# compiles the scaffold, so skip tidy (it fails when the Go checksum DB is unreachable).
+run_operator_sdk_init() {
+	local real_go wrapper rc
+
+	real_go="$(command -v go)" || abort "go not found in PATH"
+	wrapper="$(mktemp -d)"
+	cat >"${wrapper}/go" <<EOF
+#!/usr/bin/env bash
+if [[ \${1:-} == mod && \${2:-} == tidy ]]; then
+	exit 0
+fi
+exec '${real_go}' "\$@"
+EOF
+	chmod +x "${wrapper}/go"
+
+	PATH="${wrapper}:${PATH}" operator-sdk init \
+		--fetch-deps='false' \
+		--project-name="${bundle_project_name}" && rc=0 || rc=$?
+	rm -rf "${wrapper}"
+	return "${rc}"
+}
+
 create_sdk_workspace() {
 	local crd_gvks
 
@@ -196,9 +223,7 @@ create_sdk_workspace() {
 
 		log "Initializing operator-sdk project"
 
-		operator-sdk init \
-			--fetch-deps='false' \
-			--project-name="${bundle_project_name}" \
+		run_operator_sdk_init \
 			|| abort "Failed to init operator-sdk"
 
 		rm -f ./*.go go.*
@@ -213,7 +238,7 @@ create_sdk_workspace() {
 				<<<"${operator_crds}"
 		)" || abort "Failed to extract CRD GVKs"
 
-		yq --in-place --yaml-roundtrip \
+		yq --in-place --yaml-output \
 			--argjson resources "${crd_gvks}" \
 			'
         .multigroup = true
@@ -262,7 +287,7 @@ render_bundle_metadata() {
 
 	resolve_openshift_versions
 
-	yq --yaml-roundtrip \
+	yq --yaml-output \
 		--arg distribution "${DISTRIBUTION}" \
 		--arg package "${bundle_package_name}" \
 		--arg openshift_supported_versions "${OPENSHIFT_VERSIONS}" \
@@ -321,7 +346,7 @@ write_crd_manifests() {
 	)" || abort "Failed to extract CRD names"
 
 	while IFS=$'\t' read -r index name; do
-		yq --yaml-roundtrip ".[${index}]" \
+		yq --yaml-output ".[${index}]" \
 			<<<"${operator_crds}" \
 			>"${bundle_directory}/manifests/${name}.crd.yaml" \
 			|| abort "Failed to write CRD ${name}"
@@ -558,7 +583,15 @@ render_csv() {
 							}
 					)
 				]
-			| .
+			| walk(
+					if type == "object" then
+						with_entries(select((.key | tostring | startswith("__yq_comment_")) | not))
+					elif type == "array" then
+						map(select((type == "string" and startswith("__yq_comment_")) | not))
+					else
+						.
+					end
+				)
 		' \
 		<bundle.csv.yaml \
 		>"${bundle_directory}/manifests/${bundle_filename}.clusterserviceversion.yaml" \

--- a/installers/olm/generate.sh
+++ b/installers/olm/generate.sh
@@ -81,11 +81,26 @@ select_manifests() {
 	local kind="$1"
 	shift
 
-	yq --slurp --yaml-output \
+	yq --slurp --yaml-roundtrip \
 		--arg kind "${kind}" \
 		'map(select(.kind == $kind))' \
 		"$@"
 }
+
+# kislyuk --yaml-roundtrip keeps scalar quote style ("" vs '') by encoding
+# comments as __yq_comment_* keys in jq. Drop those keys so generated files
+# do not copy template comments (bundle.csv.yaml, bundle.annotations.yaml).
+yq_drop_comments='
+walk(
+  if type == "object" then
+    with_entries(select((.key | tostring | startswith("__yq_comment_")) | not))
+  elif type == "array" then
+    map(select((type == "string" and startswith("__yq_comment_")) | not))
+  else
+    .
+  end
+)
+'
 
 require() {
 	if [ $# -eq 1 ]; then
@@ -103,9 +118,9 @@ check_tools() {
 	require kubectl
 	require operator-sdk
 	require jq
-	# yq 4 --yaml-output strips comments but also literal block scalars
-	# (alm-examples). --yaml-roundtrip keeps both; comment keys are dropped
-	# in jq with strip_yq_comments.
+	# --yaml-roundtrip keeps quote style and block scalars; comments are
+	# dropped in jq via yq_drop_comments (not --yaml-output, which rewrites
+	# "" to '' and unquotes scalars).
 	require bash -c "yq --help | grep -q -- '--yaml-roundtrip'"
 
 	log "All tools available"
@@ -238,7 +253,7 @@ create_sdk_workspace() {
 				<<<"${operator_crds}"
 		)" || abort "Failed to extract CRD GVKs"
 
-		yq --in-place --yaml-output \
+		yq --in-place --yaml-roundtrip \
 			--argjson resources "${crd_gvks}" \
 			'
         .multigroup = true
@@ -287,7 +302,7 @@ render_bundle_metadata() {
 
 	resolve_openshift_versions
 
-	yq --yaml-output \
+	yq --yaml-roundtrip \
 		--arg distribution "${DISTRIBUTION}" \
 		--arg package "${bundle_package_name}" \
 		--arg openshift_supported_versions "${OPENSHIFT_VERSIONS}" \
@@ -303,6 +318,7 @@ render_bundle_metadata() {
           else
             .
           end
+        | '"${yq_drop_comments}"'
       ' \
 		<bundle.annotations.yaml \
 		>"${bundle_directory}/metadata/annotations.yaml" \
@@ -346,7 +362,7 @@ write_crd_manifests() {
 	)" || abort "Failed to extract CRD names"
 
 	while IFS=$'\t' read -r index name; do
-		yq --yaml-output ".[${index}]" \
+		yq --yaml-roundtrip ".[${index}] | ${yq_drop_comments}" \
 			<<<"${operator_crds}" \
 			>"${bundle_directory}/manifests/${name}.crd.yaml" \
 			|| abort "Failed to write CRD ${name}"
@@ -462,6 +478,11 @@ rewrite_crd_examples() {
 }
 
 apply_operator_image_to_examples() {
+	if [[ ${DISTRIBUTION} != "redhat" ]]; then
+		log "Skipping initContainer image override for ${DISTRIBUTION}"
+		return
+	fi
+
 	crd_examples="$(
 		jq \
 			--arg operator_image "${operator_image}" \
@@ -515,6 +536,7 @@ render_csv() {
 		--argjson related_images "${related_images}" \
 		"${skips_arg}" skips "${skips}" \
 		--arg target_namespaces_field_path "metadata.annotations['olm.targetNamespaces']" \
+		--arg namespace_field_path "metadata.namespace" \
 		--arg timestamp "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
 		'
 			.metadata.annotations["alm-examples"] = $examples
@@ -576,22 +598,14 @@ render_csv() {
 								.spec.template.spec.containers[].env[]?
 								| select(.name == "PGO_NAMESPACE")
 								| .valueFrom.fieldRef.fieldPath
-							) = $target_namespaces_field_path
+							) = $namespace_field_path
 						| {
 								name: .metadata.name,
 								spec
 							}
 					)
 				]
-			| walk(
-					if type == "object" then
-						with_entries(select((.key | tostring | startswith("__yq_comment_")) | not))
-					elif type == "array" then
-						map(select((type == "string" and startswith("__yq_comment_")) | not))
-					else
-						.
-					end
-				)
+			| '"${yq_drop_comments}"'
 		' \
 		<bundle.csv.yaml \
 		>"${bundle_directory}/manifests/${bundle_filename}.clusterserviceversion.yaml" \

--- a/installers/olm/generate.sh
+++ b/installers/olm/generate.sh
@@ -43,6 +43,40 @@ require_env() {
 	fi
 }
 
+# OPENSHIFT_VERSIONS, if set, is used as-is for com.redhat.openshift.versions.
+# Otherwise derive v<major.minor>-v<major.minor> from OPENSHIFT_MIN/MAX in
+# e2e-tests/release_versions. If that file is missing or unreadable, use a
+# placeholder so bundle generation can still run.
+resolve_openshift_versions() {
+	local file="${repo_root}/e2e-tests/release_versions"
+	local min max
+
+	if [[ -n ${OPENSHIFT_VERSIONS:-} ]]; then
+		log "Using OPENSHIFT_VERSIONS=${OPENSHIFT_VERSIONS}"
+		return
+	fi
+
+	if [[ ! -r ${file} ]]; then
+		OPENSHIFT_VERSIONS='@@RHEL_VERSIONS@@'
+		log "${file} is not readable; using OPENSHIFT_VERSIONS=${OPENSHIFT_VERSIONS}"
+		return
+	fi
+
+	# shellcheck source=/dev/null
+	source "${file}"
+
+	if [[ -z ${OPENSHIFT_MIN:-} || -z ${OPENSHIFT_MAX:-} ]]; then
+		OPENSHIFT_VERSIONS='@@RHEL_VERSIONS@@'
+		log "OPENSHIFT_MIN/MAX missing in ${file}; using OPENSHIFT_VERSIONS=${OPENSHIFT_VERSIONS}"
+		return
+	fi
+
+	min="$(printf '%s' "${OPENSHIFT_MIN}" | awk -F. '{print "v"$1"."$2}')"
+	max="$(printf '%s' "${OPENSHIFT_MAX}" | awk -F. '{print "v"$1"."$2}')"
+	OPENSHIFT_VERSIONS="${min}-${max}"
+	log "Derived OPENSHIFT_VERSIONS=${OPENSHIFT_VERSIONS} from OPENSHIFT_MIN=${OPENSHIFT_MIN} OPENSHIFT_MAX=${OPENSHIFT_MAX}"
+}
+
 select_manifests() {
 	local kind="$1"
 	shift
@@ -226,7 +260,7 @@ render_scorecard_tests() {
 render_bundle_metadata() {
 	log "Rendering bundle annotations for ${DISTRIBUTION}"
 
-	require_env OPENSHIFT_VERSIONS
+	resolve_openshift_versions
 
 	yq --yaml-roundtrip \
 		--arg distribution "${DISTRIBUTION}" \


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Solution:**
- The initContainer should be added to redhat only. 
- Get the OPENSHIFT_VERSIONS from release_versions file. If the OPENSHIFT_VERSIONS var is provided - it has higher prio.
- Autogenerate skips for redhat bundle
- Add logcollector to the autogenerations
- yq --yaml-roundtrip geenrated bundles with comments. Add a skip comments.
- use PGO_NAMESPACE=metadata.namespace  in both bundles.
- increase redhat_catalog_curl_timeout="${REDHAT_CATALOG_CURL_TIMEOUT:-90}"

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported PG version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
